### PR TITLE
The typechecker accepts all code in /src under HHVM-4.15-dev-2019-07-24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ www.pid
 *~
 composer.lock
 .vscode
+**/*hhast.parser-cache

--- a/src/Expressions/FunctionExpression.php
+++ b/src/Expressions/FunctionExpression.php
@@ -106,9 +106,8 @@ final class FunctionExpression extends Expression {
       foreach ($rows as $row) {
         $row as dict<_, _>;
         $val = $expr->evaluate(/* HH_FIXME[4110] generics */ $row, $conn);
-        if (!C\contains_key($buckets, $val)) {
-          $buckets[$val] = 1;
-        }
+        // Warning for future reader. This expression assigns to a `mixed` key.
+        $buckets[$val] = 1;
       }
 
       return C\count($buckets);
@@ -260,10 +259,10 @@ final class FunctionExpression extends Expression {
 
     // MySQL string positions 1-indexed, PHP strings are 0-indexed. So substract one from pos
     $pos = $args[2];
-    if ($pos is nonnull){
+    if ($pos is nonnull) {
       $count = (int)$pos->evaluate($row, $conn);
       $parts = Str\split($string, $delim);
-      if ($count < 0){
+      if ($count < 0) {
         $slice = \array_slice($parts, $count);
       } else {
         $slice = \array_slice($parts, 0, $count);

--- a/src/Expressions/FunctionExpression.php
+++ b/src/Expressions/FunctionExpression.php
@@ -106,8 +106,9 @@ final class FunctionExpression extends Expression {
       foreach ($rows as $row) {
         $row as dict<_, _>;
         $val = $expr->evaluate(/* HH_FIXME[4110] generics */ $row, $conn);
-        // Warning for future reader. This expression assigns to a `mixed` key.
-        $buckets[$val] = 1;
+        if ($val is arraykey) {
+          $buckets[$val] = 1;
+        }
       }
 
       return C\count($buckets);

--- a/src/Parser/Lexer.php
+++ b/src/Parser/Lexer.php
@@ -61,6 +61,7 @@ final class SQLLexer {
         }
 
         if (!$inline && ($token === "*/")) {
+          /*HH_IGNORE_ERROR[4110] Indexing using comment, which may be null.*/
           unset($tokens[$comment]);
           $comment = null;
         }

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -138,8 +138,9 @@ final class SelectQuery extends Query {
    * Apply the HAVING clause to every (maybe grouped) row in the data set. Only return truthy results.
    */
   protected function applyHaving(AsyncMysqlConnection $conn, dataset $data): dataset {
-    if ($this->havingClause is nonnull) {
-      return Vec\filter($data, $row ==> (bool)$this->havingClause->evaluate($row, $conn));
+    $havingClause = $this->havingClause;
+    if ($havingClause is nonnull) {
+      return Vec\filter($data, $row ==> (bool)$havingClause->evaluate($row, $conn));
     }
 
     return $data;
@@ -185,9 +186,8 @@ final class SelectQuery extends Query {
               }
             } else {
               $col = C\last($parts);
-              if (!C\contains_key($formatted_row, $col)) {
-                $formatted_row[$col] = $val;
-              }
+              // Warning for future reader. This expression assigns to a `?string` key.
+              $formatted_row[$col] ??= $val;
             }
 
           }
@@ -221,9 +221,7 @@ final class SelectQuery extends Query {
       foreach ($order_by_expressions as $order_by) {
         $row as dict<_, _>;
         list($name, $val) = $order_by['expression']->evaluateWithName(/* HH_FIXME[4110] generics */ $row, $conn);
-        if (!C\contains_key($formatted_row, $name)) {
-          $formatted_row[$name] = $val;
-        }
+        $formatted_row[$name] ??= $val;
       }
 
       $out[] = $formatted_row;

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -186,13 +186,15 @@ final class SelectQuery extends Query {
               }
             } else {
               $col = C\last($parts);
-              // Warning for future reader. This expression assigns to a `?string` key.
-              $formatted_row[$col] ??= $val;
+              if ($col is nonnull) {
+                $formatted_row[$col] ??= $val;
+              }
             }
 
           }
           continue;
         }
+
 
         list($name, $val) = $expr->evaluateWithName($row, $conn);
 


### PR DESCRIPTION
I want to help you with making this code HHVM4.NEXT compatible. If I patch out HHAST4.0.5, since this is a strict version requirement (`=4.0.5` instead of a loose requirement `^4.0.5`), it typechecks!