### PR TITLE
Add support for bitmask `&` operator

### DIFF
--- a/src/Expressions/BinaryOperatorExpression.php
+++ b/src/Expressions/BinaryOperatorExpression.php
@@ -262,10 +262,11 @@ final class BinaryOperatorExpression extends Expression {
 
         // xor here, so if negated is true and regex matches then we return false etc.
         return ((bool)\preg_match($regex, $left_string) ? 1 : 0) ^ $this->negatedInt;
+      case '&':
+        return (int)$l_value & (int)$r_value;
       case '&&':
       case 'BINARY':
       case 'COLLATE':
-      case '&':
       case '|':
       case '^':
       case '<=>':

--- a/tests/SQLFunctionTest.php
+++ b/tests/SQLFunctionTest.php
@@ -325,6 +325,23 @@ final class SQLFunctionTest extends HackTest {
 		]);
 	}
 
+	public async function testBitmaskAND(): Awaitable<void> {
+		$conn = static::$conn as nonnull;
+		$results1 = await $conn->query('SELECT id, description FROM table5 where (test_type & 1) = 1');
+		expect($results1->rows())->toBeSame(vec[
+			dict['id' => 1001, 'description' => 'desc1'],
+			dict['id' => 1002, 'description' => 'desc2'],
+			dict['id' => 1004, 'description' => 'desc4'],
+		]);
+		$results2 = await $conn->query('SELECT id, description FROM table5 where (test_type & 2) != 2');
+		expect($results2->rows())->toBeSame(vec[
+			dict['id' => 1000, 'description' => 'desc0'],
+			dict['id' => 1001, 'description' => 'desc1'],
+			dict['id' => 1002, 'description' => 'desc2'],
+			dict['id' => 1004, 'description' => 'desc4'],
+		]);
+	}
+
 	<<__Override>>
 	public static async function beforeFirstTestAsync(): Awaitable<void> {
 		static::$conn = await SharedSetup::initAsync();

--- a/tests/SharedSetup.php
+++ b/tests/SharedSetup.php
@@ -30,6 +30,13 @@ final class SharedSetup {
 				dict['id' => 1003, 'group_id' => 7, 'description' => 'desc1'],
 				dict['id' => 1004, 'group_id' => 7, 'description' => 'desc2'],
 			],
+			'table5' => vec[
+				dict['id' => 1000, 'test_type' => 0x0, 'description' => 'desc0'],
+				dict['id' => 1001, 'test_type' => 0x1, 'description' => 'desc1'],
+				dict['id' => 1002, 'test_type' => 0x1, 'description' => 'desc2'],
+				dict['id' => 1003, 'test_type' => 0x2, 'description' => 'desc3'],
+				dict['id' => 1004, 'test_type' => 0x1, 'description' => 'desc4'],
+			],
 			'association_table' => vec[
 				dict['table_3_id' => 1, 'table_4_id' => 1000, 'group_id' => 12345, 'description' => 'association 1'],
 				dict['table_3_id' => 1, 'table_4_id' => 1001, 'group_id' => 12345, 'description' => 'association 2'],
@@ -281,6 +288,32 @@ const dict<string, dict<string, table_schema>> TEST_SCHEMA = dict[
 					'fields' => keyset['group_id'],
 				),
 			],
+		),
+		'table5' => shape(
+			'name' => 'table5',
+			'fields' => vec[
+				shape(
+					'name' => 'id',
+					'type' => DataType::BIGINT,
+					'length' => 20,
+					'null' => false,
+					'hack_type' => 'int',
+				),
+				shape(
+					'name' => 'test_type',
+					'type' => DataType::INT,
+					'length' => 16,
+					'null' => false,
+					'hack_type' => 'int',
+				),
+				shape(
+					'name' => 'description',
+					'type' => DataType::VARCHAR,
+					'length' => 255,
+					'null' => false,
+					'hack_type' => 'string',
+				),
+			]
 		),
 		'association_table' => shape(
 			'name' => 'association_table',

--- a/tests/SharedSetup.php
+++ b/tests/SharedSetup.php
@@ -313,7 +313,19 @@ const dict<string, dict<string, table_schema>> TEST_SCHEMA = dict[
 					'null' => false,
 					'hack_type' => 'string',
 				),
-			]
+			],
+			'indexes' => vec[
+				shape(
+					'name' => 'PRIMARY',
+					'type' => 'PRIMARY',
+					'fields' => keyset['id'],
+				),
+				shape(
+					'name' => 'test_type',
+					'type' => 'INDEX',
+					'fields' => keyset['test_type'],
+				),
+			],
 		),
 		'association_table' => shape(
 			'name' => 'association_table',


### PR DESCRIPTION
# What

Adding support for bitmask `&` operator in where clause. 


# Test

Added test case with a bitmask column 

```
$ vendor/bin/hacktest tests     
........................................................................................................................

Summary: 120 test(s), 120 passed, 0 failed, 0 skipped, 0 error(s).
```