### PR TITLE
Add unsigned field to table schema and integer data integrity check

### DIFF
--- a/src/DataIntegrity.php
+++ b/src/DataIntegrity.php
@@ -76,6 +76,7 @@ abstract final class DataIntegrity {
       $field_mysql_type = $field['type'];
       $field_nullable = $field['null'] ?? false;
       $field_default = $field['default'] ?? null;
+      $field_unsigned = $field['unsigned'] ?? false;
 
       if (!C\contains_key($row, $field_name)) {
         $row[$field_name] =
@@ -110,27 +111,27 @@ abstract final class DataIntegrity {
             } else if ($row[$field_name] is int) {
 
                 $row[$field_name] = (int)$row[$field_name];
-                $signed_int = true;
+                $signed = !($field_unsigned);
 
                 switch($field_mysql_type) {
                   case DataType::TINYINT:
-                    if ($row[$field_name] >= (($signed_int) ? -\pow(2,7) : 0) && $row[$field_name] < (($signed_int) ? \pow(2,7) : \pow(2,8))){
+                    if ($row[$field_name] >= (($signed) ? -\pow(2,7) : 0) && $row[$field_name] < (($signed) ? \pow(2,7) : \pow(2,8))){
                       break;
                     }
                   case DataType::SMALLINT:
-                    if ($row[$field_name] >= (($signed_int) ? -\pow(2,15) : 0) && $row[$field_name] < (($signed_int) ? \pow(2,15) : \pow(2,16))){
+                    if ($row[$field_name] >= (($signed) ? -\pow(2,15) : 0) && $row[$field_name] < (($signed) ? \pow(2,15) : \pow(2,16))){
                       break;
                     }
                   case DataType::MEDIUMINT:
-                    if ($row[$field_name] >= (($signed_int) ? -\pow(2,23) : 0) && $row[$field_name] < (($signed_int) ? \pow(2,23) : \pow(2,24))){
+                    if ($row[$field_name] >= (($signed) ? -\pow(2,23) : 0) && $row[$field_name] < (($signed) ? \pow(2,23) : \pow(2,24))){
                       break;
                     }
                   case DataType::INT:
-                    if ($row[$field_name] >= (($signed_int) ? -\pow(2,31) : 0) && $row[$field_name] < (($signed_int) ? \pow(2,31) : \pow(2,32))){
+                    if ($row[$field_name] >= (($signed) ? -\pow(2,31) : 0) && $row[$field_name] < (($signed) ? \pow(2,31) : \pow(2,32))){
                       break;
                     }
                   case DataType::BIGINT:
-                    if ($row[$field_name] >= (($signed_int) ? -\pow(2,63) : 0) && $row[$field_name] < (($signed_int) ? \pow(2,63) : \pow(2,64))){
+                    if ($row[$field_name] >= (($signed) ? -\pow(2,63) : 0) && $row[$field_name] < (($signed) ? \pow(2,63) : \pow(2,64))){
                       break;
                     }
                   default:

--- a/src/DataIntegrity.php
+++ b/src/DataIntegrity.php
@@ -110,9 +110,9 @@ abstract final class DataIntegrity {
               }
             } else {
 
-                $row[$field_name] as int;
                 $signed = !($field_unsigned);
-                $field_value = $row[$field_name];
+                $field_value = (int)$row[$field_name];
+                $row[$field_name] = $field_value;
 
                 switch($field_mysql_type) {
                   case DataType::TINYINT:

--- a/src/DataIntegrity.php
+++ b/src/DataIntegrity.php
@@ -108,32 +108,48 @@ abstract final class DataIntegrity {
               } else {
                 $row[$field_name] = (int)$row[$field_name];
               }
-            } else if ($row[$field_name] is int) {
+            } else {
 
-                $row[$field_name] = (int)$row[$field_name];
+                $row[$field_name] as int;
                 $signed = !($field_unsigned);
+                $field_value = $row[$field_name];
 
                 switch($field_mysql_type) {
                   case DataType::TINYINT:
-                    if ($row[$field_name] >= (($signed) ? -\pow(2,7) : 0) && $row[$field_name] < (($signed) ? \pow(2,7) : \pow(2,8))){
-                      break;
+                    if ($field_value < (($signed) ? -\pow(2,7) : 0) || $field_value >= (($signed) ? \pow(2,7) : \pow(2,8))){
+                      throw new SQLFakeRuntimeException(
+                        "Column '{$field_name}' on '{$schema['name']}' expects a valid '{$field_mysql_type}'",
+                      );
                     }
+                    break;
                   case DataType::SMALLINT:
-                    if ($row[$field_name] >= (($signed) ? -\pow(2,15) : 0) && $row[$field_name] < (($signed) ? \pow(2,15) : \pow(2,16))){
-                      break;
+                    if ($field_value < (($signed) ? -\pow(2,15) : 0) || $field_value >= (($signed) ? \pow(2,15) : \pow(2,16))){
+                      throw new SQLFakeRuntimeException(
+                        "Column '{$field_name}' on '{$schema['name']}' expects a valid '{$field_mysql_type}'",
+                      );
                     }
+                    break;
                   case DataType::MEDIUMINT:
-                    if ($row[$field_name] >= (($signed) ? -\pow(2,23) : 0) && $row[$field_name] < (($signed) ? \pow(2,23) : \pow(2,24))){
-                      break;
+                    if ($field_value < (($signed) ? -\pow(2,23) : 0) || $field_value >= (($signed) ? \pow(2,23) : \pow(2,24))){
+                      throw new SQLFakeRuntimeException(
+                        "Column '{$field_name}' on '{$schema['name']}' expects a valid '{$field_mysql_type}'",
+                      );
                     }
+                    break;
                   case DataType::INT:
-                    if ($row[$field_name] >= (($signed) ? -\pow(2,31) : 0) && $row[$field_name] < (($signed) ? \pow(2,31) : \pow(2,32))){
-                      break;
+                    if ($field_value < (($signed) ? -\pow(2,31) : 0) || $field_value >= (($signed) ? \pow(2,31) : \pow(2,32))){
+                      throw new SQLFakeRuntimeException(
+                        "Column '{$field_name}' on '{$schema['name']}' expects a valid '{$field_mysql_type}'",
+                      );
                     }
+                    break;
                   case DataType::BIGINT:
-                    if ($row[$field_name] >= (($signed) ? -\pow(2,63) : 0) && $row[$field_name] < (($signed) ? \pow(2,63) : \pow(2,64))){
-                      break;
+                    if ($field_value < (($signed) ? -\pow(2,63) : 0) || $field_value >= (($signed) ? \pow(2,63) : \pow(2,64))){
+                      throw new SQLFakeRuntimeException(
+                        "Column '{$field_name}' on '{$schema['name']}' expects a valid '{$field_mysql_type}'",
+                      );
                     }
+                    break;
                   default:
                     throw new SQLFakeRuntimeException(
                       "Column '{$field_name}' on '{$schema['name']}' expects a valid '{$field_mysql_type}'",

--- a/src/DataIntegrity.php
+++ b/src/DataIntegrity.php
@@ -72,6 +72,8 @@ abstract final class DataIntegrity {
 
       $field_name = $field['name'];
       $field_type = $field['hack_type'];
+      $field_length = $field['length'];
+      $field_mysql_type = $field['type'];
       $field_nullable = $field['null'] ?? false;
       $field_default = $field['default'] ?? null;
 
@@ -105,6 +107,38 @@ abstract final class DataIntegrity {
               } else {
                 $row[$field_name] = (int)$row[$field_name];
               }
+            } else if ($row[$field_name] is int) {
+
+                $row[$field_name] = (int)$row[$field_name];
+                $signed_int = true;
+
+                switch($field_mysql_type) {
+                  case DataType::TINYINT:
+                    if ($row[$field_name] >= (($signed_int) ? -\pow(2,7) : 0) && $row[$field_name] < (($signed_int) ? \pow(2,7) : \pow(2,8))){
+                      break;
+                    }
+                  case DataType::SMALLINT:
+                    if ($row[$field_name] >= (($signed_int) ? -\pow(2,15) : 0) && $row[$field_name] < (($signed_int) ? \pow(2,15) : \pow(2,16))){
+                      break;
+                    }
+                  case DataType::MEDIUMINT:
+                    if ($row[$field_name] >= (($signed_int) ? -\pow(2,23) : 0) && $row[$field_name] < (($signed_int) ? \pow(2,23) : \pow(2,24))){
+                      break;
+                    }
+                  case DataType::INT:
+                    if ($row[$field_name] >= (($signed_int) ? -\pow(2,31) : 0) && $row[$field_name] < (($signed_int) ? \pow(2,31) : \pow(2,32))){
+                      break;
+                    }
+                  case DataType::BIGINT:
+                    if ($row[$field_name] >= (($signed_int) ? -\pow(2,63) : 0) && $row[$field_name] < (($signed_int) ? \pow(2,63) : \pow(2,64))){
+                      break;
+                    }
+                  default:
+                    throw new SQLFakeRuntimeException(
+                      "Column '{$field_name}' on '{$schema['name']}' expects a valid '{$field_mysql_type}'",
+                    );
+                    break;
+                }
             }
             break;
           case 'double':

--- a/src/DataIntegrity.php
+++ b/src/DataIntegrity.php
@@ -112,7 +112,6 @@ abstract final class DataIntegrity {
 
                 $signed = !($field_unsigned);
                 $field_value = (int)$row[$field_name];
-                $row[$field_name] = $field_value;
 
                 switch($field_mysql_type) {
                   case DataType::TINYINT:

--- a/src/SchemaGenerator.php
+++ b/src/SchemaGenerator.php
@@ -34,6 +34,11 @@ final class SchemaGenerator {
 				if ($default is nonnull && $default !== 'NULL') {
 					$f['default'] = $default;
 				}
+				
+				$unsigned = ($field['unsigned'] ?? null);
+				if ($unsigned is nonnull) {
+					$f['unsigned'] = $unsigned;
+				}
 				$table_generated_schema['fields'][] = $f;
 			}
 

--- a/src/SchemaGenerator.php
+++ b/src/SchemaGenerator.php
@@ -60,6 +60,7 @@ final class SchemaGenerator {
 		switch ($field['type']) {
 			case 'TINYINT':
 			case 'SMALLINT':
+			case 'MEDIUMINT':
 			case 'INT':
 			case 'BIGINT':
 				$type = 'int';

--- a/src/Types.php
+++ b/src/Types.php
@@ -127,6 +127,7 @@ type table_schema = shape(
 enum DataType: string {
   TINYINT = 'TINYINT';
   SMALLINT = 'SMALLINT';
+  MEDIUMINT = 'MEDIUMINT';
   INT = 'INT';
   BIT = 'BIT';
   BIGINT = 'BIGINT';

--- a/src/Types.php
+++ b/src/Types.php
@@ -108,6 +108,7 @@ type table_schema = shape(
       'length' => int,
       'null' => bool,
       'hack_type' => string,
+      ?'unsigned' => bool,
       ?'default' => string,
     ),
   >,

--- a/tests/GenerateSchemaTest.php
+++ b/tests/GenerateSchemaTest.php
@@ -83,6 +83,7 @@ final class GenerateSchemaTest extends HackTest {
 						'length' => 20,
 						'null' => false,
 						'hack_type' => 'int',
+						'unsigned' => true,
 					),
 					shape(
 						'name' => 'ch',
@@ -98,6 +99,7 @@ final class GenerateSchemaTest extends HackTest {
 						'null' => false,
 						'hack_type' => 'int',
 						'default' => '0',
+						'unsigned' => true,
 					),
 					shape(
 						'name' => 'name',

--- a/tests/GenerateSchemaTest.php
+++ b/tests/GenerateSchemaTest.php
@@ -46,6 +46,7 @@ final class GenerateSchemaTest extends HackTest {
 						'length' => 20,
 						'null' => false,
 						'hack_type' => 'int',
+						'unsigned' => true,
 					),
 					shape(
 						'name' => 'name',


### PR DESCRIPTION
## Summary
Add the optional unsigned field to table_schema shape in Types.php. Also added the check in schemaGenerator.php for presence of unsigned field in parsed_field shape before adding it to table_schema shape. Also commits for adding the data integrity check for integers (signed and unsigned).

## Risk
Low.