### PR TITLE
Implement clone method for Server

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -32,6 +32,18 @@ final class Server {
     return $server;
   }
 
+  public static function cloneByName(string $name, string $clone_name): this {
+    $clone = static::get($clone_name);
+    if ($clone === null) {
+        throw new SQLFakeRuntimeException("Server $clone_name not found, unable to clone databases and snapshots");
+    }
+
+    $server = static::getOrCreate($name);
+    $server->databases = $clone->databases;
+    $server->snapshots = $clone->snapshots;
+    return $server;
+  }
+
   public static function reset(): void {
     foreach (static::getAll() as $server) {
       $server->doReset();


### PR DESCRIPTION
# Summary
This pull request adds a new method to the `Server` class which will provide a mechanism to clone the `$databases` and `$snapshots` from one host to another in `hack-sql-fake`. An example use case for this might be to simulate a database backup which has been restored to another host with the same database structure and records as a production database