### PR TITLE
remove HH_IGNORE_ERRORs that are no longer needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-  - HHVM_VERSION=4.0.4
+  - HHVM_VERSION=4.8.5
 install:
 - docker pull hhvm/hhvm:$HHVM_VERSION
 script:

--- a/src/AsyncMysql/AsyncMysqlClient.php
+++ b/src/AsyncMysql/AsyncMysqlClient.php
@@ -6,7 +6,6 @@ use namespace HH\Lib\Vec;
 
 /* HHAST_IGNORE_ALL[UnusedParameter] */
 
-/* HH_IGNORE_ERROR[2049] */
 <<__MockClass>>
 final class AsyncMysqlClient extends \AsyncMysqlClient {
 

--- a/src/AsyncMysql/AsyncMysqlConnectResult.php
+++ b/src/AsyncMysql/AsyncMysqlConnectResult.php
@@ -2,7 +2,6 @@
 
 namespace Slack\SQLFake;
 
-/* HH_FIXME[2049] */
 <<__MockClass>>
 final class AsyncMysqlConnectResult extends \AsyncMysqlConnectResult {
   private int $elapsed;

--- a/src/AsyncMysql/AsyncMysqlConnection.php
+++ b/src/AsyncMysql/AsyncMysqlConnection.php
@@ -6,7 +6,6 @@ use namespace HH\Lib\Vec;
 
 /* HHAST_IGNORE_ALL[UnusedParameter] */
 
-/* HH_IGNORE_ERROR[2049] */
 <<__MockClass>>
 final class AsyncMysqlConnection extends \AsyncMysqlConnection {
 

--- a/src/AsyncMysql/AsyncMysqlQueryResult.php
+++ b/src/AsyncMysql/AsyncMysqlQueryResult.php
@@ -6,7 +6,6 @@ namespace Slack\SQLFake;
 
 use namespace HH\Lib\C;
 
-/* HH_FIXME[2049] */
 <<__MockClass>>
 final class AsyncMysqlQueryResult extends \AsyncMysqlQueryResult {
 

--- a/src/Expressions/Expression.php
+++ b/src/Expressions/Expression.php
@@ -89,7 +89,6 @@ abstract class Expression {
   protected function maybeUnrollGroupedDataset(row $rows): row {
     $first = C\first($rows);
     if ($first is dict<_, _>) {
-      /* HH_FIXME[4110] generics can't be specified here yet */
       return $first;
     }
 

--- a/src/Expressions/Expression.php
+++ b/src/Expressions/Expression.php
@@ -89,6 +89,7 @@ abstract class Expression {
   protected function maybeUnrollGroupedDataset(row $rows): row {
     $first = C\first($rows);
     if ($first is dict<_, _>) {
+      /* HH_FIXME[4110] generics can't be specified here yet */
       return $first;
     }
 

--- a/src/Parser/ExpressionParser.php
+++ b/src/Parser/ExpressionParser.php
@@ -274,7 +274,7 @@ final class ExpressionParser {
             // we assume an expression will be a Binary Operator (most common) when we first encounter a token
             // if it's something else like BETWEEN or IN, we convert it to that deliberately when encountering the operand
             $this->expression = new BinaryOperatorExpression($expr);
-          } elseif (
+          } else if (
             $this->expression->operator === null &&
             $this->expression is BinaryOperatorExpression &&
             $token['type'] === TokenType::IDENTIFIER
@@ -338,7 +338,7 @@ final class ExpressionParser {
             ) {
               $this->expression as BetweenOperatorExpression;
               $this->expression->foundAnd();
-            } elseif ($operator === Operator::NOT) {
+            } else if ($operator === Operator::NOT) {
               if ($this->expression->operator !== Operator::IS) {
                 $next = $this->peekNext();
                 if (
@@ -377,7 +377,7 @@ final class ExpressionParser {
                 // It's important to nest like this to preserve left-to-right evaluation.
                 if ($operator === Operator::BETWEEN) {
                   $this->expression = new BetweenOperatorExpression($this->expression);
-                } elseif ($operator === Operator::IN) {
+                } else if ($operator === Operator::IN) {
                   $this->expression = new InOperatorExpression($this->expression, $this->expression->negated);
                 } else {
                   $this->expression = new BinaryOperatorExpression($this->expression, false, $operator);
@@ -390,16 +390,16 @@ final class ExpressionParser {
                 throw new SQLFakeParseException('Unexpected keyword BETWEEN');
               }
               $this->expression = new BetweenOperatorExpression($this->expression->left);
-            } elseif ($operator === Operator::NOT) {
+            } else if ($operator === Operator::NOT) {
               // this negates another operator like "NOT IN" or "IS NOT NULL"
               // operators would throw an SQLFakeException here if they don't support negation
               $this->expression->negate();
-            } elseif ($operator === Operator::IN) {
+            } else if ($operator === Operator::IN) {
               if (!$this->expression is BinaryOperatorExpression) {
                 throw new SQLFakeParseException('Unexpected keyword IN');
               }
               $this->expression = new InOperatorExpression($this->expression->left, $this->expression->negated);
-            } elseif (
+            } else if (
               $operator === Operator::UNARY_MINUS || $operator === Operator::UNARY_PLUS || $operator === Operator::TILDE
             ) {
               $this->expression as PlaceholderExpression;

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -231,11 +231,10 @@ final class SelectQuery extends Query {
 
     if (C\contains_key($this->options, 'DISTINCT')) {
 
-      /*  HH_FIXME[4110] generics */
       return Vec\unique_by($out, (row $row): string ==> Str\join(Vec\map($row, $col ==> (string)$col), '-'));
     }
 
-    return /* HH_FIXME[4110] generics */ $out;
+    return $out;
   }
 
 


### PR DESCRIPTION
this PR removes `HH_IGNORE_ERROR`s that are no longer needed (HHVM 4.8.5) according to `hh_client --remove-dead-fixmes`.

the risk of this PR is low as there is no functional change — only potential impact to the typechecker.