### PR TITLE
Create a mock implementation for AsyncMysqlClientStats

### DIFF
--- a/src/AsyncMysql/AsyncMysqlClientStats.php
+++ b/src/AsyncMysql/AsyncMysqlClientStats.php
@@ -1,0 +1,35 @@
+<?hh // strict
+
+namespace Slack\SQLFake;
+
+/**
+ * This class normally records detailed statistics of the async MySQL client,
+ * mock it out since we don't execute the real client logic in SQLFake.
+ */
+<<__MockClass>>
+final class AsyncMysqlClientStats extends \AsyncMysqlClientStats {
+
+  /* HH_IGNORE_ERROR[3012] I don't want to call parent::construct */
+  public function __construct() {}
+
+  <<__Override>>
+  public function ioEventLoopMicrosAvg(): float {
+    return 0.0;
+  }
+  <<__Override>>
+  public function callbackDelayMicrosAvg(): float {
+    return 0.0;
+  }
+  <<__Override>>
+  public function ioThreadBusyMicrosAvg(): float {
+    return 0.0;
+  }
+  <<__Override>>
+  public function ioThreadIdleMicrosAvg(): float {
+    return 0.0;
+  }
+  <<__Override>>
+  public function notificationQueueSize(): int {
+    return 0;
+  }
+}

--- a/src/AsyncMysql/AsyncMysqlConnectResult.php
+++ b/src/AsyncMysql/AsyncMysqlConnectResult.php
@@ -33,6 +33,6 @@ final class AsyncMysqlConnectResult extends \AsyncMysqlConnectResult {
 
   <<__Override>>
   public function clientStats(): \AsyncMysqlClientStats {
-    throw new SQLFakeNotImplementedException('client stats not implemented');
+    return new AsyncMysqlClientStats();
   }
 }


### PR DESCRIPTION
# Description

Right now, we don't implement a mock for `AsyncMysqlConnectResult::clientStats`, this PR does that so it can be properly called during testing.

# Testing

Passes test suite.