### PR TITLE
fix LIKE query issue. 

### DIFF
--- a/src/Expressions/BinaryOperatorExpression.php
+++ b/src/Expressions/BinaryOperatorExpression.php
@@ -227,7 +227,7 @@ final class BinaryOperatorExpression extends Expression {
         }
 
         // escape all + characters
-        $pattern = \preg_quote($pattern, '+');
+        $pattern = \preg_quote($pattern, '/');
 
         // replace only unescaped % and _ characters to make regex
         $pattern = Regex\replace($pattern, re"/(?<!\\\)%/", '.*?');

--- a/src/Expressions/BinaryOperatorExpression.php
+++ b/src/Expressions/BinaryOperatorExpression.php
@@ -226,6 +226,9 @@ final class BinaryOperatorExpression extends Expression {
           $pattern = Str\strip_suffix($pattern, '%');
         }
 
+        // escape all + characters
+        $pattern = \preg_quote($pattern, '+');
+
         // replace only unescaped % and _ characters to make regex
         $pattern = Regex\replace($pattern, re"/(?<!\\\)%/", '.*?');
         $pattern = Regex\replace($pattern, re"/(?<!\\\)_/", '.');

--- a/tests/SelectExpressionTest.php
+++ b/tests/SelectExpressionTest.php
@@ -204,11 +204,11 @@ final class SelectExpressionTest extends HackTest {
 	public async function testLike(): Awaitable<void> {
 		$conn = static::$conn as nonnull;
 		$results = await $conn->query(
-			"SELECT 'foo' LIKE 'foo' as test1, 'foobarbaz' like '%bar%' test2, 'foobaz' LIKE 'foo_az' test3, 'foobarqux' like 'foo%' test4, 'foobarqux' LIKE '%qux' test5, 'blahfoobarbazqux blah' LIKE '%foo%qux%' test6, 'blegh' LIKE '%foo%' test7, 'foo+bar' LIKE '%foo+bar%' test8",
+			"SELECT 'foo' LIKE 'foo' as test1, 'foobarbaz' like '%bar%' test2, 'foobaz' LIKE 'foo_az' test3, 'foobarqux' like 'foo%' test4, 'foobarqux' LIKE '%qux' test5, 'blahfoobarbazqux blah' LIKE '%foo%qux%' test6, 'blegh' LIKE '%foo%' test7, 'foo+bar' LIKE '%foo+bar%' test8, 'foo/bar' LIKE '%foo/bar%' test9",
 		);
 		expect($results->rows())->toBeSame(
 			vec[
-				dict['test1' => 1, 'test2' => 1, 'test3' => 1, 'test4' => 1, 'test5' => 1, 'test6' => 1, 'test7' => 0, 'test8' => 1],
+				dict['test1' => 1, 'test2' => 1, 'test3' => 1, 'test4' => 1, 'test5' => 1, 'test6' => 1, 'test7' => 0, 'test8' => 1, 'test9' => 1],
 			],
 		);
 	}

--- a/tests/SelectExpressionTest.php
+++ b/tests/SelectExpressionTest.php
@@ -204,11 +204,11 @@ final class SelectExpressionTest extends HackTest {
 	public async function testLike(): Awaitable<void> {
 		$conn = static::$conn as nonnull;
 		$results = await $conn->query(
-			"SELECT 'foo' LIKE 'foo' as test1, 'foobarbaz' like '%bar%' test2, 'foobaz' LIKE 'foo_az' test3, 'foobarqux' like 'foo%' test4, 'foobarqux' LIKE '%qux' test5, 'blahfoobarbazqux blah' LIKE '%foo%qux%' test6, 'blegh' LIKE '%foo%' test7",
+			"SELECT 'foo' LIKE 'foo' as test1, 'foobarbaz' like '%bar%' test2, 'foobaz' LIKE 'foo_az' test3, 'foobarqux' like 'foo%' test4, 'foobarqux' LIKE '%qux' test5, 'blahfoobarbazqux blah' LIKE '%foo%qux%' test6, 'blegh' LIKE '%foo%' test7, 'foo+bar' LIKE '%foo+bar%' test8",
 		);
 		expect($results->rows())->toBeSame(
 			vec[
-				dict['test1' => 1, 'test2' => 1, 'test3' => 1, 'test4' => 1, 'test5' => 1, 'test6' => 1, 'test7' => 0],
+				dict['test1' => 1, 'test2' => 1, 'test3' => 1, 'test4' => 1, 'test5' => 1, 'test6' => 1, 'test7' => 0, 'test8' => 1],
 			],
 		);
 	}


### PR DESCRIPTION
`+` signs were not previously getting escaped. This meant that is you had a query `AND LIKE '%foo+bar%'` it would not work correctly. 

I escaped plus signs, and added a test. 

This is my first time making a PR against this repo. Please let me know if there is something else I need to add! 