### PR TITLE
Fix order by to properly handle lexicographical ordering of stringified numbers

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -65,7 +65,9 @@ abstract class Query {
               : 1;
           } else {
             return (
-              ((string)$value_a < (string)$value_b ? 1 : 0) ^ (($rule['direction'] === SortDirection::DESC) ? 1 : 0)
+              // Use string comparison explicity to handle lexicographical ordering of things like '125' < '5'
+              (((Str\compare((string)$value_a, (string)$value_b)) < 0) ? 1 : 0) ^
+              (($rule['direction'] === SortDirection::DESC) ? 1 : 0)
             )
               ? -1
               : 1;

--- a/tests/SelectClauseTest.php
+++ b/tests/SelectClauseTest.php
@@ -128,6 +128,17 @@ final class SelectClauseTest extends HackTest {
 				dict['group_id' => 12345, 'table_4_id' => 1000],
 			],
 		);
+
+		$results = await $conn->query('select id, position from table6 ORDER BY position ASC');
+		expect($results->rows())->toBeSame(
+			vec[
+				dict['id' => 1001, 'position' => '125'],
+				dict['id' => 1004, 'position' => '25'],
+				dict['id' => 1000, 'position' => '5'],
+				dict['id' => 1003, 'position' => '625'],
+				dict['id' => 1002, 'position' => '75'],
+			],
+		);
 	}
 
 	public async function testOrderByNotInSelect(): Awaitable<void> {

--- a/tests/SharedSetup.php
+++ b/tests/SharedSetup.php
@@ -39,6 +39,13 @@ final class SharedSetup {
 				dict['table_3_id' => 2, 'table_4_id' => 1000, 'group_id' => 12345, 'description' => 'association 3'],
 				dict['table_3_id' => 3, 'table_4_id' => 1003, 'group_id' => 0, 'description' => 'association 4'],
 			],
+			'table6' => vec[
+				dict['id' => 1000, 'position' => '5'],
+				dict['id' => 1001, 'position' => '125'],
+				dict['id' => 1002, 'position' => '75'],
+				dict['id' => 1003, 'position' => '625'],
+				dict['id' => 1004, 'position' => '25'],
+			],
 		];
 
 		$conn->getServer()->databases['db2'] = $database;
@@ -328,6 +335,32 @@ const dict<string, dict<string, table_schema>> TEST_SCHEMA = dict[
 					'type' => 'INDEX',
 					'fields' => keyset['test_type'],
 				),
+			],
+		),
+		'table6' => shape(
+			'name' => 'table6',
+			'fields' => vec[
+				shape(
+					'name' => 'id',
+					'type' => DataType::BIGINT,
+					'length' => 20,
+					'null' => false,
+					'hack_type' => 'int',
+				),
+				shape(
+					'name' => 'position',
+					'type' => DataType::VARCHAR,
+					'length' => 255,
+					'null' => false,
+					'hack_type' => 'string',
+				),
+			],
+			'indexes' => vec[
+				shape(
+					'name' => 'PRIMARY',
+					'type' => 'PRIMARY',
+					'fields' => keyset['id'],
+				)
 			],
 		),
 		'association_table' => shape(


### PR DESCRIPTION
In the case of values like '123', '5' in a varchar column, we want sql fake to perform lexicographical a la what mysql does instead of treating them like integers

I verified that the unit test I added failed before my change!