### PR TITLE
add failing test

### DIFF
--- a/src/Parser/Lexer.php
+++ b/src/Parser/Lexer.php
@@ -82,7 +82,8 @@ final class SQLLexer {
       // we need to handle sequences that look like comments, but are inside quoted strings. to do that, we also need to know when quoted strings start and end
       // since a comment could contain a quote, and a quote could contain a comment, we can't safely process either first without being aware of the other
       // so first we check if the next token should be escaped, and then if it's a quote character
-      if ($token === '\\') {
+      // checking for !$escape_next here checks for \\\\ sequences
+      if ($token === '\\' && !$escape_next) {
         $escape_next = true;
       } else {
         $escape_next = false;

--- a/tests/InsertQueryTest.php
+++ b/tests/InsertQueryTest.php
@@ -13,7 +13,7 @@ final class InsertQueryTest extends HackTest {
   public static async function beforeFirstTestAsync(): Awaitable<void> {
     init(TEST_SCHEMA, true);
     $pool = new AsyncMysqlConnectionPool(darray[]);
-    static::$conn = await $pool->connect("example", 1, 'db1', '', '');
+    static::$conn = await $pool->connect('example', 1, 'db1', '', '');
     // black hole logging
     Logger::setHandle(new \Facebook\CLILib\TestLib\StringOutput());
   }


### PR DESCRIPTION
Fix a parsing error in which MySQL accepts a string ending in `\\'` but sql-fake rejects it.