### PR TITLE
Update VitessQueryValidator.php

### DIFF
--- a/src/VitessQueryValidator.php
+++ b/src/VitessQueryValidator.php
@@ -74,9 +74,11 @@ final class UpdateQueryValidator extends VitessQueryValidator {
         $table_schema = QueryContext::getSchema($database, $table_name);
         $vitess_sharding = $table_schema['vitess_sharding'] ?? null;
 
-		if ($vitess_sharding === null) {
-			throw new SQLFakeVitessQueryViolation(Str\format('Missing Vitess sharding information for: %s', $table_name));
-		}
+	if ($vitess_sharding === null) {
+		// This could either be an unsharded table or a misconfiguration.
+		// Either way, no sharding config to validate, so let's skip it.
+		return;
+	}
 
         $columns = VitessQueryValidator::extractColumnExprNames($set);
 


### PR DESCRIPTION
### Description
Turns out, having no sharding information is actually valid, so let's not throw an exception here. Changing it to just return.