### PR TITLE
Add JSON_DEPTH & a bit of test data format cleanup

### DIFF
--- a/src/JSONPath/JSONObject.hack
+++ b/src/JSONPath/JSONObject.hack
@@ -239,6 +239,32 @@ class JSONObject {
         return new WrappedResult(1);
     }
 
+    /**
+     * Returns the maximum depth of the value.
+     */
+    public function depth(): WrappedResult<int> {
+        $depth = 0;
+
+        $objects = vec[$this->jsonObject];
+        while (!C\is_empty($objects)) {
+            $children = vec[];
+
+            foreach ($objects as $object) {
+                if ($object is dict<_, _> || $object is vec<_>) {
+                    foreach ($object as $child) {
+                        $children[] = $child;
+                    }
+                }
+            }
+
+            // Each time we enter this while loop, it means we just processed a new level
+            $depth += 1;
+            $objects = $children;
+        }
+
+        return new WrappedResult($depth);
+    }
+
     private static function pathMatched(vec<ExplodedPathType> $paths, ExplodedPathType $path): bool {
         return C\contains($paths, $path);
     }


### PR DESCRIPTION
Skipped directly testing the JSONObject->depth function since it was probably overkill in the past to do both the object + the top level JSON_* function testing.

Also refactored the JSONFunction tests to avoid writing the same test code over and over.