### PR TITLE
Prevent ORDER BY fallthrough when table name is given

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -45,8 +45,7 @@ abstract class Query {
     // allow all column expressions to fall through to the full row
     foreach ($order_by as $rule) {
       $expr = $rule['expression'];
-      
-      if ($expr is ColumnExpression && $expr->tableName === null) {
+      if ($expr is ColumnExpression && $expr->tableName() === null) {
         $expr->allowFallthrough();
       }
     }

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -45,7 +45,8 @@ abstract class Query {
     // allow all column expressions to fall through to the full row
     foreach ($order_by as $rule) {
       $expr = $rule['expression'];
-      if ($expr is ColumnExpression) {
+      
+      if ($expr is ColumnExpression && $expr->tableName === null) {
         $expr->allowFallthrough();
       }
     }


### PR DESCRIPTION
When using `ORDER BY` on the results of a `JOIN` operation we don’t want to fall through if a table name is provided in the column expression, as it can lead to invalid ordering for

```sql
SELECT foo.id
FROM foo
JOIN bar on bar.foo_id = foo.id
ORDER BY bar.id
```