### PR TITLE
fix a few bugs in the schema generator for the latest version

### DIFF
--- a/bin/hack-sql-schema
+++ b/bin/hack-sql-schema
@@ -25,7 +25,7 @@ async function hack_sql_schema_async(): Awaitable<noreturn> {
       break;
     }
     $parts = \explode('/', $root);
-    \array_pop(&$parts);
+    \array_pop(inout $parts);
     $root = \implode('/', $parts);
   }
 

--- a/src/BuildSchemaCLI.php
+++ b/src/BuildSchemaCLI.php
@@ -88,6 +88,7 @@ EOT
 								'null' => HackBuilderValues::export(),
 								'hack_type' => HackBuilderValues::export(),
 								'default' => HackBuilderValues::export(),
+								'unsigned' => HackBuilderValues::export(),
 							),
 						)),
 					),
@@ -96,8 +97,6 @@ EOT
 			->render();
 
 		$generated = <<<EOT
-<?hh // strict
-
 use type Slack\\SQLFake\\{table_schema, DataType};
 
 


### PR DESCRIPTION
- still using references instead of inout breaks the cli entrypoint
- no renderer for the `unsigned` shape key
- adding header line at the top of .hack file breaks the generated code