### PR TITLE
Query.php bug fix: bracket placement

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -211,16 +211,16 @@ abstract class Query {
           $row = DataIntegrity::coerceToSchema($row, $table_schema);
           $result = DataIntegrity::checkUniqueConstraints($original_table, $row, $table_schema, $row_id);
           if ($result is nonnull) {
-            if($this->ignoreDupes) {
+            if ($this->ignoreDupes) {
               continue;
             }
-            if(!QueryContext::$relaxUniqueConstraints) {
+            if (!QueryContext::$relaxUniqueConstraints) {
               throw new SQLFakeUniqueKeyViolation($result[0]);
             }
           }
-          $original_table[$row_id] = $row;
-          $update_count++;
         }
+        $original_table[$row_id] = $row;
+        $update_count++;
       }
     }
 


### PR DESCRIPTION
Found inadvertent moving around of brackets, causing test failures when trying to update to 4.56 at Slack! The bug was introduced [here](https://github.com/slackhq/hack-sql-fake/pull/42/files).