### PR TITLE
remove and ban inst_meth

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -1,7 +1,5 @@
 hackfmt.line_width=120
 allowed_decl_fixme_codes=2053,3012,4045,4047
 allowed_fixme_codes_strict=2011,2049,2050,2053,2083,3012,3084,4027,4038,4045,4047,4104,4105,4106,4107,4108,4110,4128,4135,4188,4223,4240,4323,4341,4390,4401
-disallow_inst_meth=true
-disallow_fun_and_cls_meth_pseudo_funcs=true
  
 

--- a/.hhconfig
+++ b/.hhconfig
@@ -1,4 +1,7 @@
 hackfmt.line_width=120
-assume_php=false
 allowed_decl_fixme_codes=2053,3012,4045,4047
 allowed_fixme_codes_strict=2011,2049,2050,2053,2083,3012,3084,4027,4038,4045,4047,4104,4105,4106,4107,4108,4110,4128,4135,4188,4223,4240,4323,4341,4390,4401
+disallow_inst_meth=true
+disallow_fun_and_cls_meth_pseudo_funcs=true
+ 
+

--- a/src/VitessQueryValidator.php
+++ b/src/VitessQueryValidator.php
@@ -98,8 +98,8 @@ final class SelectQueryValidator extends VitessQueryValidator {
     <<__Override>>
     public function getHandlers(): dict<string, (function(): Awaitable<void>)> {
         return dict[
-            UnsupportedCases::GROUP_BY_COLUMNS => inst_meth($this, 'scatterMustContainSelectColumns'),
-            UnsupportedCases::UNIONS => inst_meth($this, 'unionsNotAllowed'),
+            UnsupportedCases::GROUP_BY_COLUMNS => async () ==> await $this->scatterMustContainSelectColumns(),
+            UnsupportedCases::UNIONS => async () ==> await $this->unionsNotAllowed(),
         ];
     }
 


### PR DESCRIPTION
inst_meth will be removed from HHVM so let's get rid of the only calls in hack-sql-fake and ban it via .hhconfig. same for fun() and class_meth() which we aren't using.