### PR TITLE
move hhast to require-dev and relax requirements

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ ubuntu ]
         hhvm:
           - '4.128'
-          - '4.150'
+          - '4.153'
     runs-on: ${{matrix.os}}-latest
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     "MIT"
   ],
   "require": {
-    "hhvm/hhast": "v4.135.1",
     "hhvm/hsl-experimental": "^4.108.0",
     "facebook/hack-codegen": "^4.3.12",
     "facebook/hh-clilib": "^2.0.0",
     "hhvm/hhvm-autoload": "^2.0.13|^3.1.4"
   },
   "require-dev": {
+    "hhvm/hhast": ">=v4.135.1",
     "facebook/fbexpect": "^2.8.0",
     "hhvm/hacktest": ">=2.2.3"
   }


### PR DESCRIPTION
This is preventing installation of newer HHAST on HHVM 4.150