### PR TITLE
enable allow-plugins to fix composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,10 @@
     "hhvm/hhast": ">=v4.135.1",
     "facebook/fbexpect": "^2.8.0",
     "hhvm/hacktest": ">=2.2.3"
+  },
+  "config": {
+    "allow-plugins": {
+      "hhvm/hhvm-autoload": true
+    }
   }
 }


### PR DESCRIPTION
Fixes this build error:
```
Error: hhvm/hhvm-autoload contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
You can run "composer config --no-plugins allow-plugins.hhvm/hhvm-autoload [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)
See https://getcomposer.org/allow-plugins

```