### PR TITLE
Validate json integrity

### DIFF
--- a/src/DataIntegrity.php
+++ b/src/DataIntegrity.php
@@ -179,6 +179,8 @@ abstract final class DataIntegrity {
               }
             } else {
               $field_value = (string)$row[$field_name];
+
+              // handle json column type validation
               if ($field_mysql_type === DataType::JSON) {
                 // null is okay
                 if ($row[$field_name] is nonnull) {

--- a/tests/SharedSetup.php
+++ b/tests/SharedSetup.php
@@ -162,6 +162,32 @@ const dict<string, dict<string, table_schema>> TEST_SCHEMA = dict[
 				),
 			],
 		),
+		'table_with_json' => shape(
+			'name' => 'table_with_json',
+			'fields' => vec[
+				shape(
+					'name' => 'id',
+					'type' => DataType::BIGINT,
+					'length' => 20,
+					'null' => false,
+					'hack_type' => 'int',
+				),
+				shape(
+					'name' => 'data',
+					'type' => DataType::JSON,
+					'length' => 255,
+					'null' => true,
+					'hack_type' => 'string',
+				),
+			],
+			'indexes' => vec[
+				shape(
+					'name' => 'PRIMARY',
+					'type' => 'PRIMARY',
+					'fields' => keyset['id'],
+				)
+			],
+		),
 		'table_with_more_fields' => shape(
 			'name' => 'table_with_more_fields',
 			'fields' => vec[


### PR DESCRIPTION
Added some functionality to validate data integrity for json column types. Values inserted must be either 'NULL' or a valid json string. They cannot be an empty string.

This is in regards to two incidents at Slack which were caused by attempting to insert an empty string into a json column. This change will allow for issues like this to be caught in unit tests by SQLFake before they make it to dev or production.