### PR TITLE
unescape quotes when inserting json

### DIFF
--- a/src/DataIntegrity.php
+++ b/src/DataIntegrity.php
@@ -185,13 +185,17 @@ abstract final class DataIntegrity {
                 if ($row[$field_name] is nonnull) {
                   if (!Str\is_empty((string)$row[$field_name])) {
                     // validate json string
-                    $json_obj = \json_decode((string)$row[$field_name]);
+                    // json_decode will return null if json string contains escaped quotes - mysql just unescapes the quotes and accepts the string
+                    $json_string = \stripslashes((string)$row[$field_name]);
+                    $json_obj = \json_decode($json_string);
                     if ($json_obj is null) {
                       // invalid json
                       throw new SQLFakeRuntimeException(
                         "Invalid value '{$field_value}' for column '{$field_name}' on '{$schema['name']}', expected json",
                       );
                     }
+                    // mysql removes the \
+                    $row[$field_name] = $json_string;
                   } else {
                     // empty strings are not valid for json columns
                     throw new SQLFakeRuntimeException(

--- a/tests/InsertQueryTest.php
+++ b/tests/InsertQueryTest.php
@@ -271,9 +271,17 @@ final class InsertQueryTest extends HackTest {
   public async function testValidJsonInsertIntoJsonColumn(): Awaitable<void> {
     $conn = static::$conn as nonnull;
     QueryContext::$strictSQLMode = true;
-    await $conn->query("INSERT INTO table_with_json (id, data) VALUES (1, '{\"test\":123}')");
+    await $conn->query('INSERT INTO table_with_json (id, data) VALUES (1, \'{"test":123}\')');
     $result = await $conn->query('SELECT * FROM table_with_json');
     expect($result->rows())->toBeSame(vec[dict['id' => 1, 'data' => '{"test":123}']]);
+  }
+
+  public async function testValidJsonWithQuotesEscapedInsertIntoJsonColumn(): Awaitable<void> {
+    $conn = static::$conn as nonnull;
+    QueryContext::$strictSQLMode = true;
+    await $conn->query('INSERT INTO table_with_json (id, data) VALUES (1, \'{\\\"domains\\\":[\\\"foo.com\\\"]}\')');
+    $result = await $conn->query('SELECT * FROM table_with_json');
+    expect($result->rows())->toBeSame(vec[dict['id' => 1, 'data' => '{"domains":["foo.com"]}']]);
   }
 
   public async function testDupeInsertNoConflicts(): Awaitable<void> {


### PR DESCRIPTION
Some of the tests breaking in webapp with the new version of hack-sql-fake are failing because we are inserting escaped json strings. Currently in sql-fake we are using json_encode to test the validity of json and considering it invalid if it returns null. However, this function returns null if passed a valid json string with escaped quotes.

Mysql will accept json strings with escaped quotes and just unescape them. This PR modifies sql-fake to do the same, this way we can pass escaped json strings and they will be accepted, which matches the actual behavior of mysql.