### PR TITLE
Revert "unescape quotes when inserting json"

### DIFF
--- a/src/DataIntegrity.php
+++ b/src/DataIntegrity.php
@@ -185,17 +185,13 @@ abstract final class DataIntegrity {
                 if ($row[$field_name] is nonnull) {
                   if (!Str\is_empty((string)$row[$field_name])) {
                     // validate json string
-                    // json_decode will return null if json string contains escaped quotes - mysql just unescapes the quotes and accepts the string
-                    $json_string = \stripslashes((string)$row[$field_name]);
-                    $json_obj = \json_decode($json_string);
+                    $json_obj = \json_decode((string)$row[$field_name]);
                     if ($json_obj is null) {
                       // invalid json
                       throw new SQLFakeRuntimeException(
                         "Invalid value '{$field_value}' for column '{$field_name}' on '{$schema['name']}', expected json",
                       );
                     }
-                    // mysql removes the \
-                    $row[$field_name] = $json_string;
                   } else {
                     // empty strings are not valid for json columns
                     throw new SQLFakeRuntimeException(

--- a/tests/InsertQueryTest.php
+++ b/tests/InsertQueryTest.php
@@ -271,17 +271,9 @@ final class InsertQueryTest extends HackTest {
   public async function testValidJsonInsertIntoJsonColumn(): Awaitable<void> {
     $conn = static::$conn as nonnull;
     QueryContext::$strictSQLMode = true;
-    await $conn->query('INSERT INTO table_with_json (id, data) VALUES (1, \'{"test":123}\')');
+    await $conn->query("INSERT INTO table_with_json (id, data) VALUES (1, '{\"test\":123}')");
     $result = await $conn->query('SELECT * FROM table_with_json');
     expect($result->rows())->toBeSame(vec[dict['id' => 1, 'data' => '{"test":123}']]);
-  }
-
-  public async function testValidJsonWithQuotesEscapedInsertIntoJsonColumn(): Awaitable<void> {
-    $conn = static::$conn as nonnull;
-    QueryContext::$strictSQLMode = true;
-    await $conn->query('INSERT INTO table_with_json (id, data) VALUES (1, \'{\\\"domains\\\":[\\\"foo.com\\\"]}\')');
-    $result = await $conn->query('SELECT * FROM table_with_json');
-    expect($result->rows())->toBeSame(vec[dict['id' => 1, 'data' => '{"domains":["foo.com"]}']]);
   }
 
   public async function testDupeInsertNoConflicts(): Awaitable<void> {


### PR DESCRIPTION
Reverts slackhq/hack-sql-fake#95

This was erroneous and actually breaks some legitimate use cases.