### PR TITLE
Fix elapsedMicros always returning zero

### DIFF
--- a/src/AsyncMysql/AsyncMysqlConnectResult.php
+++ b/src/AsyncMysql/AsyncMysqlConnectResult.php
@@ -20,7 +20,7 @@ final class AsyncMysqlConnectResult extends \AsyncMysqlConnectResult {
 
   <<__Override>>
   public function elapsedMicros(): int {
-    return (int)($this->elapsed / 1000000);
+    return (int)($this->elapsed * 1_000_000);
   }
   <<__Override>>
   public function startTime(): float {


### PR DESCRIPTION
`$this->start` and `$this->end` have the same unit, inferred via `endTime()`. That function adds the two without doing a unit conversion first. `$this->start` has the unit seconds.

`elapsedMicros()` used to divide by 1_000_000 and return megaseconds. By swapping the division with a multiplication, `elapsedMicros()` now returns microseconds.