### PR TITLE
Convert table_schema type to TableSchema object

### DIFF
--- a/src/BuildSchemaCLI.php
+++ b/src/BuildSchemaCLI.php
@@ -5,18 +5,18 @@ namespace Slack\SQLFake;
 use namespace HH\Lib\{C, Regex};
 use type Facebook\CLILib\CLIWithArguments;
 use namespace Facebook\CLILib\CLIOptions;
-use type Facebook\HackCodegen\{HackBuilderKeys, HackBuilderValues, HackCodegenConfig, HackCodegenFactory};
+use function var_export, preg_replace;
 
 final class BuildSchemaCLI extends CLIWithArguments {
-	private string $constName = 'DB_SCHEMA';
+	private string $functionName = 'get_db_schema';
 
 	<<__Override>>
 	protected function getSupportedOptions(): vec<CLIOptions\CLIOption> {
 		return vec[CLIOptions\with_required_string(
 			$name ==> {
-				$this->constName = $name;
+				$this->functionName = $name;
 			},
-			'The name of the constant to generate. Defaults to DB_SCHEMA',
+			'The name of the function name to generate. Defaults to get_db_schema',
 			'--name',
 		)];
 	}
@@ -67,43 +67,96 @@ EOT
 			$generated[$db] = $schema;
 		}
 
-		$cg = new HackCodegenFactory(new HackCodegenConfig());
-
-		$generated = $cg->codegenConstant($this->constName)
-			->setType('dict<string, dict<string, table_schema>>')
-			->setValue($generated, HackBuilderValues::dict(HackBuilderKeys::export(), HackBuilderValues::dict(
-				HackBuilderKeys::export(),
-				// special exporters are required to make shapes and enum values, ::export would turn them into arrays and strings
-				HackBuilderValues::shapeWithPerKeyRendering(
-					shape(
-						'name' => HackBuilderValues::export(),
-						'indexes' =>
-							HackBuilderValues::vec(HackBuilderValues::shapeWithUniformRendering(HackBuilderValues::export())),
-						'fields' => HackBuilderValues::vec(HackBuilderValues::shapeWithPerKeyRendering(
-							shape(
-								'name' => HackBuilderValues::export(),
-								'type' => HackBuilderValues::lambda(($_cfg, $str) ==> 'DataType::'.$str),
-								'length' => HackBuilderValues::export(),
-								'null' => HackBuilderValues::export(),
-								'hack_type' => HackBuilderValues::export(),
-								'default' => HackBuilderValues::export(),
-								'unsigned' => HackBuilderValues::export(),
-							),
-						)),
-					),
-				),
-			)))
-			->render();
-
-		$generated = <<<EOT
-use type Slack\\SQLFake\\{table_schema, DataType};
-
-
-EOT
-			.
-			$generated;
+		$generated = self::getRenderedHackTableSchemaWithClusters($this->functionName, $generated);
 
 		await $terminal->getStdout()->writeAllAsync($generated);
 		return 0;
+	}
+
+	//
+	// Write out a top level import target containing all of our generated db files.
+	//
+	// This also contains a memoized function that returns a lookup for each field in our DB tables and the type of those fields.
+	//
+
+	public static function getRenderedHackTableSchemaWithClusters(
+		string $function_name,
+		dict<string, dict<string, TableSchema>> $table_schemas,
+	): string {
+		$file_contents = '';
+
+		$file_contents .= "use type Slack\\SQLFake\\{Column, DataType, Index, TableSchema};\n";
+		$file_contents .= "\n";
+		$file_contents .= "<<__Memoize>>\n";
+		$file_contents .= "function {$function_name}(): dict<string, dict<string, table_schema>> {\n";
+		$file_contents .= "\treturn dict[\n";
+		foreach ($table_schemas as $cluster => $tables) {
+			$file_contents .= "\t\t'{$cluster}' => ".self::getRenderedHackTableSchema($tables, "\t\t");
+		}
+		$file_contents .= "\t];\n";
+		$file_contents .= "}\n";
+
+		return $file_contents;
+	}
+
+	public static function getRenderedHackTableSchema(
+		dict<string, TableSchema> $table_schemas,
+		string $indentation,
+	): string {
+		$file_contents = "dict[\n";
+		foreach ($table_schemas as $table_schema) {
+			$table_name = $table_schema->name;
+			$file_contents .= $indentation."\t'{$table_name}' => new TableSchema(\n";
+
+			//
+			// Write out the fields
+			//
+
+			$file_contents .= $indentation."\t\t'{$table_name}',\n";
+			$file_contents .= $indentation."\t\tvec[\n";
+			foreach ($table_schema->fields as $field) {
+				$file_contents .= $indentation."\t\t\tnew Column(\n";
+				$file_contents .= $indentation."\t\t\t\t'{$field->name}',\n";
+				$file_contents .= $indentation."\t\t\t\tDataType::{$field->type},\n";
+				$file_contents .= $indentation."\t\t\t\t{$field->length},\n";
+				$file_contents .= $indentation."\t\t\t\t" . ($field->null ? 'true' : 'false') . ",\n";
+				$file_contents .= $indentation."\t\t\t\t'{$field->hack_type}',\n";
+				if ($field->unsigned is nonnull || $field->default is nonnull) {
+					if ($field->unsigned is nonnull) {
+						$file_contents .= $indentation."\t\t\t\t" . ($field->unsigned ? 'true' : 'false') . ",\n";
+					} else {
+						$file_contents .= $indentation."\t\t\t\tnull,\n";
+					}
+					if ($field->default is nonnull) {
+						$file_contents .= $indentation."\t\t\t\t'{$field->default}',\n";
+					}
+				}
+				$file_contents .= $indentation."\t\t\t),\n";
+			}
+			$file_contents .= $indentation."\t\t],\n";
+
+			//
+			// Write out the indexes
+			//
+
+			$file_contents .= $indentation."\t\tvec[\n";
+			foreach ($table_schema->indexes as $index) {
+				$file_contents .= $indentation."\t\t\tnew Index(\n";
+				$file_contents .= $indentation."\t\t\t\t'{$index->name}',\n";
+				$file_contents .= $indentation."\t\t\t\t'{$index->type}',\n";
+				$fields = 'keyset[\''.\implode('\', \'', $index->fields).'\']';
+				$file_contents .= $indentation."\t\t\t\t{$fields},\n";
+				$file_contents .= $indentation."\t\t\t),\n";
+			}
+			$file_contents .= $indentation."\t\t],\n";
+			$file_contents .= $indentation."\t),\n";
+		}
+
+		$file_contents .= $indentation."],\n";
+		return $file_contents;
+	}
+
+	private static function varExportStringArray(Container<string> $array): string {
+		return C\is_empty($array) ? 'vec[]' : 'vec[\''.\HH\Lib\Str\join($array, '\', \'').'\']';
 	}
 }

--- a/src/BuildSchemaCLI.php
+++ b/src/BuildSchemaCLI.php
@@ -5,7 +5,6 @@ namespace Slack\SQLFake;
 use namespace HH\Lib\{C, Regex};
 use type Facebook\CLILib\CLIWithArguments;
 use namespace Facebook\CLILib\CLIOptions;
-use function var_export, preg_replace;
 
 final class BuildSchemaCLI extends CLIWithArguments {
 	private string $functionName = 'get_db_schema';

--- a/src/Column.hack
+++ b/src/Column.hack
@@ -1,0 +1,13 @@
+namespace Slack\SQLFake;
+
+final class Column {
+	public function __construct(
+		public string $name,
+		public DataType $type,
+		public int $length,
+		public bool $null,
+		public string $hack_type,
+		public ?bool $unsigned = null,
+		public ?string $default = null,
+	) {}
+}

--- a/src/Index.hack
+++ b/src/Index.hack
@@ -1,0 +1,5 @@
+namespace Slack\SQLFake;
+
+final class Index {
+	public function __construct(public string $name, public string $type, public keyset<string> $fields) {}
+}

--- a/src/Init.php
+++ b/src/Init.php
@@ -17,7 +17,7 @@ namespace Slack\SQLFake;
  * If strict mode is provided (recommended), SQLFake will throw an exception on any query referencing tables not in the schema.
  */
 function init(
-	dict<string, dict<string, table_schema>> $schema = dict[],
+	dict<string, dict<string, TableSchema>> $schema = dict[],
 	bool $strict_sql = false,
 	bool $strict_schema = false,
 ): void {

--- a/src/Query/FromClause.php
+++ b/src/Query/FromClause.php
@@ -78,8 +78,8 @@ final class FromClause {
 			} else if ($schema is nonnull) {
 				// if schema is set, order the fields in the right order on each row
 				$ordered_fields = keyset[];
-				foreach ($schema['fields'] as $field) {
-					$ordered_fields[] = $field['name'];
+				foreach ($schema->fields as $field) {
+					$ordered_fields[] = $field->name;
 				}
 
 				foreach ($res as $row) {

--- a/src/Query/JoinProcessor.php
+++ b/src/Query/JoinProcessor.php
@@ -20,7 +20,7 @@ abstract final class JoinProcessor {
 		JoinType $join_type,
 		?JoinOperator $_ref_type,
 		?Expression $ref_clause,
-		?table_schema $right_schema,
+		?TableSchema $right_schema,
 	): dataset {
 
 		// MySQL supports JOIN (inner), LEFT OUTER JOIN, RIGHT OUTER JOIN, and implicitly CROSS JOIN (which uses commas), NATURAL
@@ -76,8 +76,8 @@ abstract final class JoinProcessor {
 				// this null placeholder row is merged into the data set for that row
 				$null_placeholder = dict[];
 				if ($right_schema !== null) {
-					foreach ($right_schema['fields'] as $field) {
-						$null_placeholder["{$right_table_name}.{$field['name']}"] = null;
+					foreach ($right_schema->fields as $field) {
+						$null_placeholder["{$right_table_name}.{$field->name}"] = null;
 					}
 				}
 
@@ -109,8 +109,8 @@ abstract final class JoinProcessor {
 
 				$null_placeholder = dict[];
 				if ($right_schema !== null) {
-					foreach ($right_schema['fields'] as $field) {
-						$null_placeholder["{$right_table_name}.{$field['name']}"] = null;
+					foreach ($right_schema->fields as $field) {
+						$null_placeholder["{$right_table_name}.{$field->name}"] = null;
 					}
 				}
 
@@ -180,7 +180,9 @@ abstract final class JoinProcessor {
 
 		// MySQL actually doesn't throw if there's no matching columns, but I think we can take the liberty to assume it's not what you meant to do and throw here
 		if ($filter === null) {
-			throw new SQLFakeParseException('NATURAL join keyword was used with tables that do not share any column names');
+			throw new SQLFakeParseException(
+				'NATURAL join keyword was used with tables that do not share any column names',
+			);
 		}
 
 		return $filter;
@@ -235,7 +237,7 @@ abstract final class JoinProcessor {
 		JoinType $join_type,
 		?JoinOperator $_ref_type,
 		BinaryOperatorExpression $filter,
-		?table_schema $right_schema,
+		?TableSchema $right_schema,
 	): dataset {
 		$left = $filter->left as ColumnExpression;
 		$right = $filter->right as ColumnExpression;
@@ -273,8 +275,8 @@ abstract final class JoinProcessor {
 				// this null placeholder row is merged into the data set for that row
 				$null_placeholder = dict[];
 				if ($right_schema !== null) {
-					foreach ($right_schema['fields'] as $field) {
-						$null_placeholder["{$right_table_name}.{$field['name']}"] = null;
+					foreach ($right_schema->fields as $field) {
+						$null_placeholder["{$right_table_name}.{$field->name}"] = null;
 					}
 				}
 

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -149,7 +149,7 @@ abstract class Query {
 		dataset $filtered_rows,
 		dataset $original_table,
 		vec<BinaryOperatorExpression> $set_clause,
-		?table_schema $table_schema,
+		?TableSchema $table_schema,
 		/* for dupe inserts only */
 		?row $values = null,
 	): (int, vec<dict<string, mixed>>) {
@@ -158,7 +158,7 @@ abstract class Query {
 
 		$valid_fields = null;
 		if ($table_schema !== null) {
-			$valid_fields = Keyset\map($table_schema['fields'], $field ==> $field['name']);
+			$valid_fields = Keyset\map($table_schema->fields, $field ==> $field->name);
 		}
 
 		$set_clauses = vec[];

--- a/src/QueryContext.php
+++ b/src/QueryContext.php
@@ -45,9 +45,9 @@ abstract final class QueryContext {
 	 * servers with the same name but different schemas. We don't include server hostnames here
 	 * because it's common to have sharded databases with the same names on different hosts
 	 */
-	public static dict<string, dict<string, table_schema>> $schema = dict[];
+	public static dict<string, dict<string, TableSchema>> $schema = dict[];
 
-	public static function getSchema(string $database, string $table): ?table_schema {
+	public static function getSchema(string $database, string $table): ?TableSchema {
 		return self::$schema[$database][$table] ?? null;
 	}
 }

--- a/src/TableSchema.hack
+++ b/src/TableSchema.hack
@@ -1,0 +1,24 @@
+namespace Slack\SQLFake;
+
+/**
+ * A simple representation of a table schema, used to make the application smarter.
+ * This allows SQL Fake to provide fully typed rows, validate that columns exist,
+ * enforce primary key constraints, check if indexes would be used, and more
+ */
+final class TableSchema implements IMemoizeParam {
+	public function __construct(
+		public string $name,
+		public vec<Column> $fields = vec[],
+		public vec<Index> $indexes = vec[],
+		public ?VitessSharding $vitess_sharding = null,
+	) {}
+
+	public function getInstanceKey(): string {
+		return $this->name;
+	}
+
+	public function getPrimaryKeyColumns(): keyset<string> {
+		$primary = \HH\Lib\Vec\filter($this->indexes, $index ==> $index->name === 'PRIMARY')[0];
+		return $primary->fields;
+	}
+}

--- a/src/Types.php
+++ b/src/Types.php
@@ -91,41 +91,6 @@ type limit_clause = shape(
 
 type order_by_clause = vec<shape('expression' => Expression, 'direction' => SortDirection)>;
 
-/**
- * A simple representation of a table schema, used to make the application smarter.
- * This allows SQL Fake to provide fully typed rows, validate that columns exist,
- * enforce primary key constraints, check if indexes would be used, and more
- */
-type table_schema = shape(
-
-	/**
-	 * Table name as it exists in the database
-	 */
-	'name' => string,
-	'fields' => Container<
-		shape(
-			'name' => string,
-			'type' => DataType,
-			'length' => int,
-			'null' => bool,
-			'hack_type' => string,
-			?'unsigned' => bool,
-			?'default' => string,
-		),
-	>,
-	'indexes' => Container<
-		shape(
-			'name' => string,
-			'type' => string,
-			'fields' => Container<string>,
-		),
-	>,
-	?'vitess_sharding' => shape(
-		'keyspace' => string,
-		'sharding_key' => string,
-	),
-);
-
 enum DataType: string {
 	TINYINT = 'TINYINT';
 	SMALLINT = 'SMALLINT';

--- a/src/VitessQueryValidator.php
+++ b/src/VitessQueryValidator.php
@@ -86,7 +86,7 @@ final class UpdateQueryValidator extends VitessQueryValidator {
 
 		list($database, $table_name) = Query::parseTableName($this->conn, $this->query->updateClause['name']);
 		$table_schema = QueryContext::getSchema($database, $table_name);
-		$vitess_sharding = $table_schema['vitess_sharding'] ?? null;
+		$vitess_sharding = $table_schema?->vitess_sharding;
 
 		if ($vitess_sharding === null) {
 			// This could either be an unsharded table or a misconfiguration.
@@ -96,7 +96,7 @@ final class UpdateQueryValidator extends VitessQueryValidator {
 
 		$columns = VitessQueryValidator::extractColumnExprNames($set);
 
-		if (C\contains_key($columns, $vitess_sharding['sharding_key'])) {
+		if (C\contains_key($columns, $vitess_sharding->sharding_key)) {
 			throw new SQLFakeVitessQueryViolation(
 				Str\format('Vitess query validation error: %s', UnsupportedCases::PRIMARY_VINDEX_COLUMN),
 			);
@@ -132,7 +132,7 @@ final class SelectQueryValidator extends VitessQueryValidator {
 			$where = $this->query->whereClause;
 			list($database, $table_name) = Query::parseTableName($this->conn, $table['name']);
 			$table_schema = QueryContext::getSchema($database, $table_name);
-			$vitess_sharding = $table_schema['vitess_sharding'] ?? null;
+			$vitess_sharding = $table_schema?->vitess_sharding ?? null;
 			// if we don't have a sharding scheme defined, assume it isn't cross shard
 			if ($vitess_sharding === null) {
 				$is_scatter_query = false;
@@ -142,7 +142,7 @@ final class SelectQueryValidator extends VitessQueryValidator {
 			if ($where is BinaryOperatorExpression) {
 				$columns = VitessQueryValidator::extractColumnExprNames($where->traverse());
 				// if the where clause selects on the sharding key, we're good to go
-				if (C\contains_key($columns, $vitess_sharding['sharding_key'])) {
+				if (C\contains_key($columns, $vitess_sharding->sharding_key)) {
 					// TODO: for now this just returns but we need to eventually
 					// handle cases like JOINS where multiple tables are involved
 					return false;

--- a/src/VitessSharding.hack
+++ b/src/VitessSharding.hack
@@ -1,0 +1,5 @@
+namespace Slack\SQLFake;
+
+class VitessSharding {
+	public function __construct(public string $keyspace, public string $sharding_key) {}
+}

--- a/tests/InsertQueryTest.php
+++ b/tests/InsertQueryTest.php
@@ -11,7 +11,7 @@ final class InsertQueryTest extends HackTest {
 
 	<<__Override>>
 	public static async function beforeFirstTestAsync(): Awaitable<void> {
-		init(TEST_SCHEMA, true);
+		init(get_test_schema(), true);
 		$pool = new AsyncMysqlConnectionPool(darray[]);
 		static::$conn = await $pool->connect('example', 1, 'db1', '', '');
 		// black hole logging

--- a/tests/SharedSetup.php
+++ b/tests/SharedSetup.php
@@ -4,7 +4,7 @@ namespace Slack\SQLFake;
 
 final class SharedSetup {
 	public static async function initAsync(): Awaitable<AsyncMysqlConnection> {
-		$schema = TEST_SCHEMA;
+		$schema = get_test_schema();
 		init($schema, true);
 
 		$pool = new AsyncMysqlConnectionPool(darray[]);
@@ -55,7 +55,7 @@ final class SharedSetup {
 	}
 
 	public static async function initVitessAsync(): Awaitable<AsyncMysqlConnection> {
-		$schema = VITESS_TEST_SCHEMA;
+		$schema = get_vitess_test_schema();
 		init($schema, true);
 
 		$pool = new AsyncMysqlConnectionPool(darray[]);
@@ -91,491 +91,169 @@ final class SharedSetup {
 
 }
 
-const dict<string, dict<string, table_schema>> TEST_SCHEMA = dict[
-	'db1' => dict[
-		'table1' => shape(
-			'name' => 'table1',
-			'fields' => vec[
-				shape(
-					'name' => 'id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'name',
-					'type' => DataType::VARCHAR,
-					'length' => 255,
-					'null' => false,
-					'hack_type' => 'string',
-				),
-			],
-			'indexes' => vec[
-				shape(
-					'name' => 'PRIMARY',
-					'type' => 'PRIMARY',
-					'fields' => keyset['id'],
-				),
-				shape(
-					'name' => 'name_uniq',
-					'type' => 'UNIQUE',
-					'fields' => keyset['name'],
-				),
-			],
-		),
-		'table2' => shape(
-			'name' => 'table2',
-			'fields' => vec[
-				shape(
-					'name' => 'id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'table_1_id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'description',
-					'type' => DataType::VARCHAR,
-					'length' => 255,
-					'null' => false,
-					'hack_type' => 'string',
-				),
-			],
-			'indexes' => vec[
-				shape(
-					'name' => 'PRIMARY',
-					'type' => 'PRIMARY',
-					'fields' => keyset['id'],
-				),
-				shape(
-					'name' => 'table_1_id',
-					'type' => 'INDEX',
-					'fields' => keyset['table_1_id'],
-				),
-			],
-		),
-		'table_with_json' => shape(
-			'name' => 'table_with_json',
-			'fields' => vec[
-				shape(
-					'name' => 'id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'data',
-					'type' => DataType::JSON,
-					'length' => 255,
-					'null' => true,
-					'hack_type' => 'string',
-				),
-			],
-			'indexes' => vec[
-				shape(
-					'name' => 'PRIMARY',
-					'type' => 'PRIMARY',
-					'fields' => keyset['id'],
-				),
-			],
-		),
-		'table_with_more_fields' => shape(
-			'name' => 'table_with_more_fields',
-			'fields' => vec[
-				shape(
-					'name' => 'id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'name',
-					'type' => DataType::VARCHAR,
-					'length' => 255,
-					'null' => false,
-					'hack_type' => 'string',
-				),
-				shape(
-					'name' => 'nullable_unique',
-					'type' => DataType::VARCHAR,
-					'length' => 255,
-					'null' => true,
-					'hack_type' => 'string',
-				),
-				shape(
-					'name' => 'nullable_default',
-					'type' => DataType::INT,
-					'length' => 20,
-					'null' => true,
-					'hack_type' => 'int',
-					'default' => '1',
-				),
-				shape(
-					'name' => 'not_null_default',
-					'type' => DataType::INT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-					'default' => '2',
-				),
-			],
-			'indexes' => vec[
-				shape(
-					'name' => 'PRIMARY',
-					'type' => 'PRIMARY',
-					'fields' => keyset['id', 'name'],
-				),
-				shape(
-					'name' => 'nullable_unique',
-					'type' => 'UNIQUE',
-					'fields' => keyset['nullable_unique'],
-				),
-			],
-		),
-	],
-	'db2' => dict[
-		'table3' => shape(
-			'name' => 'table3',
-			'fields' => vec[
-				shape(
-					'name' => 'id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'group_id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'name',
-					'type' => DataType::VARCHAR,
-					'length' => 255,
-					'null' => false,
-					'hack_type' => 'string',
-				),
-			],
-			'indexes' => vec[
-				shape(
-					'name' => 'PRIMARY',
-					'type' => 'PRIMARY',
-					'fields' => keyset['id'],
-				),
-				shape(
-					'name' => 'name_uniq',
-					'type' => 'UNIQUE',
-					'fields' => keyset['name'],
-				),
-				shape(
-					'name' => 'group_id',
-					'type' => 'INDEX',
-					'fields' => keyset['group_id'],
-				),
-			],
-		),
-		'table4' => shape(
-			'name' => 'table4',
-			'fields' => vec[
-				shape(
-					'name' => 'id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'group_id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'description',
-					'type' => DataType::VARCHAR,
-					'length' => 255,
-					'null' => false,
-					'hack_type' => 'string',
-				),
-			],
-			'indexes' => vec[
-				shape(
-					'name' => 'PRIMARY',
-					'type' => 'PRIMARY',
-					'fields' => keyset['id'],
-				),
-				shape(
-					'name' => 'group_id',
-					'type' => 'INDEX',
-					'fields' => keyset['group_id'],
-				),
-			],
-		),
-		'table5' => shape(
-			'name' => 'table5',
-			'fields' => vec[
-				shape(
-					'name' => 'id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'test_type',
-					'type' => DataType::INT,
-					'length' => 16,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'description',
-					'type' => DataType::VARCHAR,
-					'length' => 255,
-					'null' => false,
-					'hack_type' => 'string',
-				),
-			],
-			'indexes' => vec[
-				shape(
-					'name' => 'PRIMARY',
-					'type' => 'PRIMARY',
-					'fields' => keyset['id'],
-				),
-				shape(
-					'name' => 'test_type',
-					'type' => 'INDEX',
-					'fields' => keyset['test_type'],
-				),
-			],
-		),
-		'table6' => shape(
-			'name' => 'table6',
-			'fields' => vec[
-				shape(
-					'name' => 'id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'position',
-					'type' => DataType::VARCHAR,
-					'length' => 255,
-					'null' => false,
-					'hack_type' => 'string',
-				),
-			],
-			'indexes' => vec[
-				shape(
-					'name' => 'PRIMARY',
-					'type' => 'PRIMARY',
-					'fields' => keyset['id'],
-				),
-			],
-		),
-		'association_table' => shape(
-			'name' => 'association_table',
-			'fields' => vec[
-				shape(
-					'name' => 'table_3_id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'table_4_id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'description',
-					'type' => DataType::VARCHAR,
-					'length' => 255,
-					'null' => false,
-					'hack_type' => 'string',
-				),
-				shape(
-					'name' => 'group_id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-			],
-			'indexes' => vec[
-				shape(
-					'name' => 'PRIMARY',
-					'type' => 'PRIMARY',
-					'fields' => keyset['table_3_id', 'table_4_id'],
-				),
-				shape(
-					'name' => 'table_4_id',
-					'type' => 'INDEX',
-					'fields' => keyset['table_4_id'],
-				),
-			],
-		),
-	],
-
-];
-
-const dict<string, dict<string, table_schema>> VITESS_TEST_SCHEMA = dict[
-	'vitess' => dict[
-		'vt_table1' => shape(
-			'name' => 'vt_table1',
-			'fields' => vec[
-				shape(
-					'name' => 'id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'name',
-					'type' => DataType::VARCHAR,
-					'length' => 255,
-					'null' => false,
-					'hack_type' => 'string',
-				),
-			],
-			'indexes' => vec[
-				shape(
-					'name' => 'PRIMARY',
-					'type' => 'PRIMARY',
-					'fields' => keyset['id'],
-				),
-				shape(
-					'name' => 'name_uniq',
-					'type' => 'UNIQUE',
-					'fields' => keyset['name'],
-				),
-			],
-			'vitess_sharding' => shape(
-				'keyspace' => 'test_keyspace_one',
-				'sharding_key' => 'id',
+<<__Memoize>>
+function get_test_schema(): dict<string, dict<string, TableSchema>> {
+	return dict[
+		'db1' => dict[
+			'table1' => new TableSchema(
+				'table1',
+				vec[
+					new Column('id', DataType::BIGINT, 20, false, 'int'),
+					new Column('name', DataType::VARCHAR, 255, false, 'string'),
+				],
+				vec[
+					new Index('PRIMARY', 'PRIMARY', keyset['id']),
+					new Index('name_uniq', 'UNIQUE', keyset['name']),
+				],
 			),
-		),
-		'vt_table2' => shape(
-			'name' => 'vt_table2',
-			'fields' => vec[
-				shape(
-					'name' => 'id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'vt_table1_id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'description',
-					'type' => DataType::VARCHAR,
-					'length' => 255,
-					'null' => false,
-					'hack_type' => 'string',
-				),
-			],
-			'indexes' => vec[
-				shape(
-					'name' => 'PRIMARY',
-					'type' => 'PRIMARY',
-					'fields' => keyset['id'],
-				),
-				shape(
-					'name' => 'table_1_id',
-					'type' => 'INDEX',
-					'fields' => keyset['vt_table1_id'],
-				),
-			],
-			'vitess_sharding' => shape(
-				'keyspace' => 'test_keyspace_one',
-				'sharding_key' => 'vt_table1_id',
+			'table2' => new TableSchema(
+				'table2',
+				vec[
+					new Column('id', DataType::BIGINT, 20, false, 'int'),
+					new Column('table_1_id', DataType::BIGINT, 20, false, 'int'),
+					new Column('description', DataType::VARCHAR, 255, false, 'string'),
+				],
+				vec[
+					new Index('PRIMARY', 'PRIMARY', keyset['id']),
+					new Index('table_1_id', 'INDEX', keyset['table_1_id']),
+				],
 			),
-
-		),
-		'vt_table_with_more_fields' => shape(
-			'name' => 'vt_table_with_more_fields',
-			'fields' => vec[
-				shape(
-					'name' => 'id',
-					'type' => DataType::BIGINT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-				),
-				shape(
-					'name' => 'name',
-					'type' => DataType::VARCHAR,
-					'length' => 255,
-					'null' => false,
-					'hack_type' => 'string',
-				),
-				shape(
-					'name' => 'nullable_unique',
-					'type' => DataType::VARCHAR,
-					'length' => 255,
-					'null' => true,
-					'hack_type' => 'string',
-				),
-				shape(
-					'name' => 'nullable_default',
-					'type' => DataType::INT,
-					'length' => 20,
-					'null' => true,
-					'hack_type' => 'int',
-					'default' => '1',
-				),
-				shape(
-					'name' => 'not_null_default',
-					'type' => DataType::INT,
-					'length' => 20,
-					'null' => false,
-					'hack_type' => 'int',
-					'default' => '2',
-				),
-			],
-			'indexes' => vec[
-				shape(
-					'name' => 'PRIMARY',
-					'type' => 'PRIMARY',
-					'fields' => keyset['id', 'name'],
-				),
-				shape(
-					'name' => 'nullable_unique',
-					'type' => 'UNIQUE',
-					'fields' => keyset['nullable_unique'],
-				),
-			],
-			'vitess_sharding' => shape(
-				'keyspace' => 'test_keyspace_two',
-				'sharding_key' => 'name',
+			'table_with_json' => new TableSchema(
+				'table_with_json',
+				vec[
+					new Column('id', DataType::BIGINT, 20, false, 'int'),
+					new Column('data', DataType::JSON, 255, true, 'string'),
+				],
+				vec[
+					new Index('PRIMARY', 'PRIMARY', keyset['id']),
+				],
 			),
+			'table_with_more_fields' => new TableSchema(
+				'table_with_more_fields',
+				vec[
+					new Column('id', DataType::BIGINT, 20, false, 'int'),
+					new Column('name', DataType::VARCHAR, 255, false, 'string'),
+					new Column('nullable_unique', DataType::VARCHAR, 255, true, 'string'),
+					new Column('nullable_default', DataType::INT, 20, true, 'int', null, '1'),
+					new Column('not_null_default', DataType::INT, 20, false, 'int', null, '2'),
+				],
+				vec[
+					new Index('PRIMARY', 'PRIMARY', keyset['id', 'name']),
+					new Index('nullable_unique', 'UNIQUE', keyset['nullable_unique']),
+				],
+			),
+		],
+		'db2' => dict[
+			'table3' => new TableSchema(
+				'table3',
+				vec[
+					new Column('id', DataType::BIGINT, 20, false, 'int'),
+					new Column('group_id', DataType::BIGINT, 20, false, 'int'),
+					new Column('name', DataType::VARCHAR, 255, false, 'string'),
+				],
+				vec[
+					new Index('PRIMARY', 'PRIMARY', keyset['id']),
+					new Index('name_uniq', 'UNIQUE', keyset['name']),
+					new Index('group_id', 'INDEX', keyset['group_id']),
+				],
+			),
+			'table4' => new TableSchema(
+				'table4',
+				vec[
+					new Column('id', DataType::BIGINT, 20, false, 'int'),
+					new Column('group_id', DataType::BIGINT, 20, false, 'int'),
+					new Column('description', DataType::VARCHAR, 255, false, 'string'),
+				],
+				vec[
+					new Index('PRIMARY', 'PRIMARY', keyset['id']),
+					new Index('group_id', 'INDEX', keyset['group_id']),
+				],
+			),
+			'table5' => new TableSchema(
+				'table5',
+				vec[
+					new Column('id', DataType::BIGINT, 20, false, 'int'),
+					new Column('test_type', DataType::INT, 16, false, 'int'),
+					new Column('description', DataType::VARCHAR, 255, false, 'string'),
+				],
+				vec[
+					new Index('PRIMARY', 'PRIMARY', keyset['id']),
+					new Index('test_type', 'INDEX', keyset['test_type']),
+				],
+			),
+			'table6' => new TableSchema(
+				'table6',
+				vec[
+					new Column('id', DataType::BIGINT, 20, false, 'int'),
+					new Column('position', DataType::VARCHAR, 255, false, 'string'),
+				],
+				vec[
+					new Index('PRIMARY', 'PRIMARY', keyset['id']),
+				],
+			),
+			'association_table' => new TableSchema(
+				'association_table',
+				vec[
+					new Column('table_3_id', DataType::BIGINT, 20, false, 'int'),
+					new Column('table_4_id', DataType::BIGINT, 20, false, 'int'),
+					new Column('description', DataType::VARCHAR, 255, false, 'string'),
+					new Column('group_id', DataType::BIGINT, 20, false, 'int'),
+				],
+				vec[
+					new Index('PRIMARY', 'PRIMARY', keyset['table_3_id', 'table_4_id']),
+					new Index('table_4_id', 'INDEX', keyset['table_4_id']),
+				],
+			),
+		],
 
-		),
-	],
-];
+	];
+}
+
+function get_vitess_test_schema(): dict<string, dict<string, TableSchema>> {
+	return dict[
+		'vitess' => dict[
+			'vt_table1' => new TableSchema(
+				'vt_table1',
+				vec[
+					new Column('id', DataType::BIGINT, 20, false, 'int'),
+					new Column('name', DataType::VARCHAR, 255, false, 'string'),
+				],
+				vec[
+					new Index('PRIMARY', 'PRIMARY', keyset['id']),
+					new Index('name_uniq', 'UNIQUE', keyset['name']),
+				],
+				new VitessSharding('test_keyspace_one', 'id'),
+			),
+			'vt_table2' => new TableSchema(
+				'vt_table2',
+				vec[
+					new Column('id', DataType::BIGINT, 20, false, 'int'),
+					new Column('vt_table1_id', DataType::BIGINT, 20, false, 'int'),
+					new Column('description', DataType::VARCHAR, 255, false, 'string'),
+				],
+				vec[
+					new Index('PRIMARY', 'PRIMARY', keyset['id']),
+					new Index('table_1_id', 'INDEX', keyset['vt_table1_id']),
+				],
+				new VitessSharding('test_keyspace_one', 'vt_table1_id'),
+
+			),
+			'vt_table_with_more_fields' => new TableSchema(
+				'vt_table_with_more_fields',
+				vec[
+					new Column('id', DataType::BIGINT, 20, false, 'int'),
+					new Column('name', DataType::VARCHAR, 255, false, 'string'),
+					new Column('nullable_unique', DataType::VARCHAR, 255, true, 'string'),
+					new Column('nullable_default', DataType::INT, 20, true, 'int', null, '1'),
+					new Column('not_null_default', DataType::INT, 20, false, 'int', null, '2'),
+				],
+				vec[
+					new Index('PRIMARY', 'PRIMARY', keyset['id', 'name']),
+					new Index('nullable_unique', 'UNIQUE', keyset['nullable_unique']),
+				],
+				new VitessSharding('test_keyspace_two', 'name'),
+
+			),
+		],
+	];
+}

--- a/tests/fixtures/expected_schema.codegen
+++ b/tests/fixtures/expected_schema.codegen
@@ -1,0 +1,115 @@
+use type Slack\SQLFake\{Column, DataType, Index, TableSchema};
+
+<<__Memoize>>
+function get_my_table_schemas(): dict<string, dict<string, table_schema>> {
+	return dict[
+		'prod' => dict[
+			'test' => new TableSchema(
+				'test',
+				vec[
+					new Column(
+						'id',
+						DataType::VARCHAR,
+						255,
+						false,
+						'string',
+					),
+					new Column(
+						'value',
+						DataType::VARCHAR,
+						255,
+						false,
+						'string',
+					),
+				],
+				vec[
+					new Index(
+						'PRIMARY',
+						'PRIMARY',
+						keyset['id'],
+					),
+				],
+			),
+			'test2' => new TableSchema(
+				'test2',
+				vec[
+					new Column(
+						'id',
+						DataType::BIGINT,
+						20,
+						false,
+						'int',
+						true,
+					),
+					new Column(
+						'name',
+						DataType::VARCHAR,
+						100,
+						false,
+						'string',
+					),
+				],
+				vec[
+					new Index(
+						'PRIMARY',
+						'PRIMARY',
+						keyset['id', 'name'],
+					),
+					new Index(
+						'name',
+						'INDEX',
+						keyset['name'],
+					),
+				],
+			),
+			'test3' => new TableSchema(
+				'test3',
+				vec[
+					new Column(
+						'id',
+						DataType::BIGINT,
+						20,
+						false,
+						'int',
+						true,
+					),
+					new Column(
+						'ch',
+						DataType::CHAR,
+						64,
+						true,
+						'string',
+					),
+					new Column(
+						'deleted',
+						DataType::TINYINT,
+						3,
+						false,
+						'int',
+						true,
+						'0',
+					),
+					new Column(
+						'name',
+						DataType::VARCHAR,
+						100,
+						false,
+						'string',
+					),
+				],
+				vec[
+					new Index(
+						'PRIMARY',
+						'PRIMARY',
+						keyset['id'],
+					),
+					new Index(
+						'name',
+						'UNIQUE',
+						keyset['name'],
+					),
+				],
+			),
+		],
+	];
+}


### PR DESCRIPTION
This PR starts along the road to a larger refactor of how we calculate query results.

Migrating the `table_schema` shape to a `TableSchema` class makes referencing the data in `hack-sql-fake` slightly easier.