### PR TITLE
Use indexes to filter WHERE queries

### DIFF
--- a/src/Expressions/BetweenOperatorExpression.php
+++ b/src/Expressions/BetweenOperatorExpression.php
@@ -51,6 +51,11 @@ final class BetweenOperatorExpression extends Expression {
 	}
 
 	<<__Override>>
+	public function getIndexCandidates(dict<string, Column> $_columns): ?dict<string, mixed> {
+		return null;
+	}
+
+	<<__Override>>
 	public function negate(): void {
 		$this->negated = true;
 	}

--- a/src/Expressions/BinaryOperatorExpression.php
+++ b/src/Expressions/BinaryOperatorExpression.php
@@ -100,7 +100,9 @@ final class BinaryOperatorExpression extends Expression {
 
 		if ($left is RowExpression) {
 			if (!$right is RowExpression) {
-				throw new SQLFakeRuntimeException('Expected row expression on RHS of '.(string)$this->operator.' operand');
+				throw new SQLFakeRuntimeException(
+					'Expected row expression on RHS of '.(string)$this->operator.' operand',
+				);
 			}
 
 			// oh fun! a row comparison, e.g. (col1, col2, col3) > (1, 2, 3)
@@ -164,7 +166,8 @@ final class BinaryOperatorExpression extends Expression {
 				}
 			case Operator::GREATER_THAN:
 				if ($as_string) {
-					return (bool)((((Str\compare((string)$l_value, (string)$r_value)) > 0) ? 1 : 0) ^ $this->negatedInt);
+					return
+						(bool)((((Str\compare((string)$l_value, (string)$r_value)) > 0) ? 1 : 0) ^ $this->negatedInt);
 				} else {
 					return (bool)(((float)$l_value > (float)$r_value) ? 1 : 0 ^ $this->negatedInt);
 				}
@@ -177,7 +180,8 @@ final class BinaryOperatorExpression extends Expression {
 				}
 			case Operator::LESS_THAN:
 				if ($as_string) {
-					return (bool)((((Str\compare((string)$l_value, (string)$r_value)) < 0) ? 1 : 0) ^ $this->negatedInt);
+					return
+						(bool)((((Str\compare((string)$l_value, (string)$r_value)) < 0) ? 1 : 0) ^ $this->negatedInt);
 				} else {
 					return (bool)(((float)$l_value < (float)$r_value) ? 1 : 0 ^ $this->negatedInt);
 				}
@@ -222,7 +226,9 @@ final class BinaryOperatorExpression extends Expression {
 					case Operator::DOUBLE_GREATER_THAN:
 						return (int)$left_number >> (int)$right_number;
 					default:
-						throw new SQLFakeRuntimeException('Operator '.(string)$this->operator.' recognized but not implemented');
+						throw new SQLFakeRuntimeException(
+							'Operator '.(string)$this->operator.' recognized but not implemented',
+						);
 				}
 			case Operator::LIKE:
 				$left_string = (string)$left->evaluate($row, $conn);
@@ -303,22 +309,51 @@ final class BinaryOperatorExpression extends Expression {
 		}
 	}
 
-	private static function getColumnNamesFromBinop(BinaryOperatorExpression $expr): dict<string, mixed> {
+	<<__Override>>
+	public function getIndexCandidates(dict<string, Column> $columns): ?dict<string, mixed> {
+		$op = $this->operator;
+		if ($op === null) {
+			// an operator should only be in this state in the middle of parsing, never when evaluating
+			throw new SQLFakeRuntimeException('Attempted to evaluate BinaryOperatorExpression with empty operator');
+		}
+
+		if ($this->negated) {
+			return null;
+		}
+
+		return self::getColumnNamesFromBinop($this, $columns);
+	}
+
+	private static function getColumnNamesFromBinop(
+		BinaryOperatorExpression $expr,
+		dict<string, Column> $columns,
+	): dict<string, mixed> {
 		$column_names = dict[];
 
 		if ($expr->operator === Operator::EQUALS) {
 			if ($expr->left is ColumnExpression && $expr->left->name !== '*' && $expr->right is ConstantExpression) {
-				$column_names[$expr->left->name] = $expr->right->value;
+				$table_name = $expr->left->tableName;
+				$column_name = $expr->left->name;
+				if ($table_name is nonnull) {
+					$column_name = $table_name.'.'.$column_name;
+				}
+				$value = $expr->right->value;
+				if (isset($columns[$column_name])) {
+					if ($columns[$column_name]->hack_type === 'int') {
+						$value = (int)$value;
+					}
+				}
+				$column_names[$column_name] = $value;
 			}
 		}
 
 		if ($expr->operator === Operator::AND) {
 			if ($expr->left is BinaryOperatorExpression) {
-				$column_names = self::getColumnNamesFromBinop($expr->left);
+				$column_names = self::getColumnNamesFromBinop($expr->left, $columns);
 			}
 
 			if ($expr->right is BinaryOperatorExpression) {
-				$column_names = Dict\merge($column_names, self::getColumnNamesFromBinop($expr->right));
+				$column_names = Dict\merge($column_names, self::getColumnNamesFromBinop($expr->right, $columns));
 			}
 		}
 

--- a/src/Expressions/CaseOperatorExpression.php
+++ b/src/Expressions/CaseOperatorExpression.php
@@ -45,6 +45,11 @@ final class CaseOperatorExpression extends Expression {
 	}
 
 	<<__Override>>
+	public function getIndexCandidates(dict<string, Column> $_columns): ?dict<string, mixed> {
+		return null;
+	}
+
+	<<__Override>>
 	public function isWellFormed(): bool {
 		return $this->wellFormed;
 	}

--- a/src/Expressions/ColumnExpression.php
+++ b/src/Expressions/ColumnExpression.php
@@ -77,6 +77,11 @@ final class ColumnExpression extends Expression {
 		}
 	}
 
+	<<__Override>>
+	public function getIndexCandidates(dict<string, Column> $_columns): ?dict<string, mixed> {
+		return null;
+	}
+
 	/**
 	 * for use in ORDER BY... allow evaluating the expression
 	 * to fall through to the full row if the column is not found fully qualified.

--- a/src/Expressions/ConstantExpression.php
+++ b/src/Expressions/ConstantExpression.php
@@ -43,6 +43,11 @@ final class ConstantExpression extends Expression {
 	}
 
 	<<__Override>>
+	public function getIndexCandidates(dict<string, Column> $_columns): ?dict<string, mixed> {
+		return null;
+	}
+
+	<<__Override>>
 	public function isWellFormed(): bool {
 		return true;
 	}

--- a/src/Expressions/Expression.php
+++ b/src/Expressions/Expression.php
@@ -70,6 +70,8 @@ abstract class Expression {
 		return $result;
 	}
 
+	public abstract function getIndexCandidates(dict<string, Column> $columns): ?dict<string, mixed>;
+
 	/**
 	 * a lot of times you just want the value
 	 */

--- a/src/Expressions/FunctionExpression.php
+++ b/src/Expressions/FunctionExpression.php
@@ -68,6 +68,11 @@ final class FunctionExpression extends BaseFunctionExpression {
 		}
 	}
 
+	<<__Override>>
+	public function getIndexCandidates(dict<string, Column> $_columns): ?dict<string, mixed> {
+		return null;
+	}
+
 	public function isAggregate(): bool {
 		return C\contains_key(keyset['COUNT', 'SUM', 'MIN', 'MAX', 'AVG'], $this->functionName);
 	}

--- a/src/Expressions/InOperatorExpression.php
+++ b/src/Expressions/InOperatorExpression.php
@@ -70,6 +70,11 @@ final class InOperatorExpression extends Expression {
 	}
 
 	<<__Override>>
+	public function getIndexCandidates(dict<string, Column> $_columns): ?dict<string, mixed> {
+		return null;
+	}
+
+	<<__Override>>
 	public function negate(): void {
 		$this->negated = true;
 	}

--- a/src/Expressions/JSONFunctionExpression.hack
+++ b/src/Expressions/JSONFunctionExpression.hack
@@ -45,6 +45,11 @@ final class JSONFunctionExpression extends BaseFunctionExpression {
 		throw new SQLFakeRuntimeException('Function '.$this->functionName.' not implemented yet');
 	}
 
+	<<__Override>>
+	public function getIndexCandidates(dict<string, Column> $_columns): ?dict<string, mixed> {
+		return null;
+	}
+
 	private function sqlJSONValid(row $row, AsyncMysqlConnection $conn): ?bool {
 		$row = $this->maybeUnrollGroupedDataset($row);
 		$args = $this->args;

--- a/src/Expressions/PlaceholderExpression.php
+++ b/src/Expressions/PlaceholderExpression.php
@@ -21,6 +21,11 @@ final class PlaceholderExpression extends Expression {
 	}
 
 	<<__Override>>
+	public function getIndexCandidates(dict<string, Column> $_columns): ?dict<string, mixed> {
+		return null;
+	}
+
+	<<__Override>>
 	public function isWellFormed(): bool {
 		return false;
 	}

--- a/src/Expressions/RowExpression.php
+++ b/src/Expressions/RowExpression.php
@@ -26,6 +26,11 @@ final class RowExpression extends Expression {
 	}
 
 	<<__Override>>
+	public function getIndexCandidates(dict<string, Column> $_columns): ?dict<string, mixed> {
+		return null;
+	}
+
+	<<__Override>>
 	public function isWellFormed(): bool {
 		return true;
 	}

--- a/src/Expressions/SubqueryExpression.php
+++ b/src/Expressions/SubqueryExpression.php
@@ -23,6 +23,11 @@ final class SubqueryExpression extends Expression {
 	}
 
 	<<__Override>>
+	public function getIndexCandidates(dict<string, Column> $_columns): ?dict<string, mixed> {
+		return null;
+	}
+
+	<<__Override>>
 	public function isWellFormed(): bool {
 		return true;
 	}

--- a/src/Expressions/UnaryExpression.php
+++ b/src/Expressions/UnaryExpression.php
@@ -43,6 +43,11 @@ final class UnaryExpression extends Expression {
 	}
 
 	<<__Override>>
+	public function getIndexCandidates(dict<string, Column> $_columns): ?dict<string, mixed> {
+		return null;
+	}
+
+	<<__Override>>
 	public function setNextChild(Expression $expr, bool $overwrite = false): void {
 		if ($this->subject is nonnull && !$overwrite) {
 			throw new SQLFakeParseException('Unexpected expression after unary operand');

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -55,7 +55,7 @@ final class SelectQuery extends Query {
 			// FROM clause handling - builds a data set including extracting rows from tables, applying joins
 			$this->applyFrom($conn)
 			// WHERE caluse - filter out any rows that don't match it
-			|> $this->applyWhere($conn, $$[0])
+			|> $this->applyWhere($conn, $$[0], $$[1], $$[2], $$[4], $$[3])
 			// GROUP BY clause - may group the rows if necessary. all clauses after this need to know how to handled both grouped and ungrouped inputs
 			|> $this->applyGroupBy($conn, $$)
 			// HAVING clause, filter out any rows not matching it

--- a/src/Query/UpdateQuery.php
+++ b/src/Query/UpdateQuery.php
@@ -13,8 +13,17 @@ final class UpdateQuery extends Query {
 		Metrics::trackQuery(QueryType::UPDATE, $conn->getServer()->name, $tableName, $this->sql);
 		$schema = QueryContext::getSchema($database, $tableName);
 
+		$columns = null;
+
+		if ($schema?->fields is nonnull) {
+			$columns = dict[];
+			foreach ($schema?->fields as $field) {
+				$columns[$field->name] = $field;
+			}
+		}
+
 		list($rows_affected, $_, $_, $_) =
-			$this->applyWhere($conn, $data)
+			$this->applyWhere($conn, $data, $unique_index_refs, $index_refs, $columns, $schema?->indexes)
 			|> $this->applyOrderBy($conn, $$)
 			|> $this->applyLimit($$)
 			|> $this->applySet(


### PR DESCRIPTION
This changes the behaviour of hack-sql-fake to use pre-calculated indexes for quick retrieval. We will leverage this ability further in future PRs, allowing us to flag queries with no indexes.