### PR TITLE
Add 'rank' as the reserved word

### DIFF
--- a/src/Parser/SQLParser.php
+++ b/src/Parser/SQLParser.php
@@ -607,5 +607,6 @@ final class SQLParser {
 		'DELAYED',
 		'LOW_PRIORITY',
 		'HIGH_PRIORITY',
+		'RANK',
 	];
 }


### PR DESCRIPTION
```
mysql> SELECT `id`,`channel_id`,`payload`,`type`,`ts`,`date_create`,`date_update`,`date_delete`,`rank`,`parent_id` FROM bookmarks WHERE channel_id = 1159130243347 AND date_delete = 1686781283 ORDER BY rank ASC;
ERROR 1105 (HY000): syntax error at position 203 near 'ASC'

mysql> SELECT `id`,`channel_id`,`payload`,`type`,`ts`,`date_create`,`date_update`,`date_delete`,`rank`,`parent_id` FROM bookmarks WHERE channel_id = 1159130243347 AND date_delete = 1686781283 ORDER BY `rank` ASC;
Empty set (0.00 sec)
```

```
The rank is a MySQL reserved word defined in MySQL version 8.0. 2. Therefore, you cannot use rank as a column name. You need to use backticks around the rank.
```

discussion thread https://slack-pde.slack.com/archives/CQGR39RA5/p1686854907680839?thread_ts=1686781600.137799&cid=CQGR39RA5