### PR TITLE
Add TIMESTAMP to SchemaGenerator

### DIFF
--- a/src/SchemaGenerator.php
+++ b/src/SchemaGenerator.php
@@ -85,6 +85,7 @@ final class SchemaGenerator {
 			case 'VARBINARY':
 			case 'DATE':
 			case 'DATETIME':
+			case 'TIMESTAMP':
 			// These are represented in SQL as strings, however they're stored in a binary format, and
 			// storing anything other than JSON should be a runtime error.
 			case 'JSON':


### PR DESCRIPTION
Also already understood by CreateTableParser, just not SchemaGenerator.

These are not integers - they are strings in the range '1970-01-01 00:00:01' to '2038-01-19 03:14:07'