### PR TITLE
Fix evaluation of <foo>=NULL

### DIFF
--- a/src/Expressions/BinaryOperatorExpression.php
+++ b/src/Expressions/BinaryOperatorExpression.php
@@ -154,6 +154,12 @@ final class BinaryOperatorExpression extends Expression {
 			case Operator::OR:
 				invariant(false, 'impossible to arrive here');
 			case Operator::EQUALS:
+				// foo = NULL is always NULL, no matter what the value of foo
+				// (specifically, if foo is also NULL!). Negation of NULL is always
+				// NULL, so we ignore that.
+				if ($l_value is null || $r_value is null) {
+					return null;
+				}
 				// maybe do some stuff with data types here
 				// comparing strings: gotta think about collation and case sensitivity!
 				return (bool)(\HH\Lib\Legacy_FIXME\eq($l_value, $r_value) ? 1 : 0 ^ $this->negatedInt);

--- a/tests/SelectExpressionTest.php
+++ b/tests/SelectExpressionTest.php
@@ -158,14 +158,10 @@ final class SelectExpressionTest extends HackTest {
 			'adding a column reference still parses',
 		);
 
-		$results = await $conn->query('SELECT id FROM table4 WHERE id IN (1000 + 2)');
-		expect($results->rows())->toBeSame(
-			vec[
-				dict['id' => 1002],
-			],
-		);
-
 		$results = await $conn->query('SELECT id FROM table4 WHERE id IN (NULL)');
+		expect($results->rows())->toBeEmpty();
+
+		$results = await $conn->query('SELECT id FROM table4 WHERE id IN (NULL=NULL)');
 		expect($results->rows())->toBeEmpty();
 	}
 

--- a/tests/SelectExpressionTest.php
+++ b/tests/SelectExpressionTest.php
@@ -46,8 +46,9 @@ final class SelectExpressionTest extends HackTest {
 
 	public async function testSelectExpressions(): Awaitable<void> {
 		$conn = static::$conn as nonnull;
-		$results =
-			await $conn->query('SELECT id, group_id as my_fav_group_id, id*1000 as math FROM table3 WHERE group_id=6');
+		$results = await $conn->query(
+			'SELECT id, group_id as my_fav_group_id, id*1000 as math FROM table3 WHERE group_id=6',
+		);
 		expect($results->rows())->toBeSame(
 			vec[
 				dict['id' => 4, 'my_fav_group_id' => 6, 'math' => 4000],
@@ -156,6 +157,16 @@ final class SelectExpressionTest extends HackTest {
 			],
 			'adding a column reference still parses',
 		);
+
+		$results = await $conn->query('SELECT id FROM table4 WHERE id IN (1000 + 2)');
+		expect($results->rows())->toBeSame(
+			vec[
+				dict['id' => 1002],
+			],
+		);
+
+		$results = await $conn->query('SELECT id FROM table4 WHERE id IN (NULL)');
+		expect($results->rows())->toBeEmpty();
 	}
 
 	public async function testNotIn(): Awaitable<void> {
@@ -199,7 +210,9 @@ final class SelectExpressionTest extends HackTest {
 
 		// weird this is even valid SQL, and possibly pedantic, but this demonstrates a lot of how
 		// case statements are implemented such that it doesn't blow up on the second THEN or second CASE
-		$results = await $conn->query("SELECT CASE WHEN 4 = CASE WHEN 1 = 2 THEN 3 ELSE 4 END THEN 'yes' ELSE 'no' END");
+		$results = await $conn->query(
+			"SELECT CASE WHEN 4 = CASE WHEN 1 = 2 THEN 3 ELSE 4 END THEN 'yes' ELSE 'no' END",
+		);
 		expect($results->rows())->toBeSame(
 			vec[
 				dict["CASE WHEN 4 = CASE WHEN 1 = 2 THEN 3 ELSE 4 END THEN 'yes' ELSE 'no' END" => 'yes'],
@@ -321,6 +334,21 @@ final class SelectExpressionTest extends HackTest {
 		]);
 	}
 
+	public async function testEqualsNull(): Awaitable<void> {
+		$conn = static::$conn as nonnull;
+		$results = await $conn->query('SELECT id FROM table3 WHERE NULL=NULL');
+		expect($results->rows())->toBeEmpty();
+
+		$results = await $conn->query('SELECT id FROM table3 WHERE NULL!=NULL');
+		expect($results->rows())->toBeEmpty();
+
+		$results = await $conn->query('SELECT id FROM table3 WHERE table_3_id=NULL');
+		expect($results->rows())->toBeEmpty();
+
+		$results = await $conn->query('SELECT id FROM table3 WHERE table_3_id!=NULL');
+		expect($results->rows())->toBeEmpty();
+	}
+
 	public async function testIsNotNull(): Awaitable<void> {
 		$conn = static::$conn as nonnull;
 		$results = await $conn->query(
@@ -338,7 +366,9 @@ final class SelectExpressionTest extends HackTest {
 
 	public async function testNotParens(): Awaitable<void> {
 		$conn = static::$conn as nonnull;
-		$results = await $conn->query("SELECT id FROM table3 WHERE group_id=12345 AND NOT (name='name1' OR name='name3')");
+		$results = await $conn->query(
+			"SELECT id FROM table3 WHERE group_id=12345 AND NOT (name='name1' OR name='name3')",
+		);
 		expect($results->rows())->toBeSame(vec[
 			dict['id' => 2],
 		]);


### PR DESCRIPTION
`<foo>=NULL` is always `NULL`, but previously this would evaluate to `true` or `false`, depending on the value of `<foo>`. Fix that and add tests.