### PR TITLE
Evaluate expressions in IN predicates when performing index checks

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -40,7 +40,15 @@ abstract class Query {
 		$all_matched = false;
 
 		if ($columns is nonnull && $indexes) {
-			$data = QueryPlanner::filterWithIndexes($data, $index_refs, $columns, $indexes, $where, inout $all_matched);
+			$data = QueryPlanner::filterWithIndexes(
+				$conn,
+				$data,
+				$index_refs,
+				$columns,
+				$indexes,
+				$where,
+				inout $all_matched,
+			);
 		}
 
 		if (!$all_matched) {


### PR DESCRIPTION
When performing index checks, we need to know what values are in `IN` lists. 