### PR TITLE
add AsyncMysqlQueryErrorResult and SQLFakeAsyncMysqlException

### DIFF
--- a/src/AsyncMysql/AsyncMysqlQueryErrorResult.hack
+++ b/src/AsyncMysql/AsyncMysqlQueryErrorResult.hack
@@ -3,8 +3,9 @@ namespace Slack\SQLFake;
 <<__MockClass>>
 final class AsyncMysqlQueryErrorResult extends \AsyncMysqlQueryErrorResult {
 
-	/* HH_IGNORE_ERROR[3012] I don't want to call parent::construct */
-	public function __construct(private int $mysql_errno = 1105, private string $mysql_error = 'ERUnknownError') {}
+	public function __construct(private int $mysql_errno = 1105, private string $mysql_error = 'ERUnknownError') {
+		parent::__construct();
+	}
 
 	<<__Override>>
 	// HHAST_IGNORE_ERROR[CamelCasedMethodsUnderscoredFunctions]

--- a/src/AsyncMysql/AsyncMysqlQueryErrorResult.hack
+++ b/src/AsyncMysql/AsyncMysqlQueryErrorResult.hack
@@ -1,5 +1,3 @@
-<?hh // strict
-
 namespace Slack\SQLFake;
 
 use namespace HH\Lib\C;
@@ -11,11 +9,13 @@ final class AsyncMysqlQueryErrorResult extends \AsyncMysqlQueryErrorResult {
 	public function __construct(private int $mysql_errno = 1105, private string $mysql_error = 'ERUnknownError') {}
 
 	<<__Override>>
+	// HHAST_IGNORE_ERROR[CamelCasedMethodsUnderscoredFunctions]
 	public function mysql_errno(): int {
 		return $this->mysql_errno;
 	}
 
 	<<__Override>>
+	// HHAST_IGNORE_ERROR[CamelCasedMethodsUnderscoredFunctions]
 	public function mysql_error(): string {
 		return $this->mysql_error;
 	}

--- a/src/AsyncMysql/AsyncMysqlQueryErrorResult.hack
+++ b/src/AsyncMysql/AsyncMysqlQueryErrorResult.hack
@@ -1,7 +1,5 @@
 namespace Slack\SQLFake;
 
-use namespace HH\Lib\C;
-
 <<__MockClass>>
 final class AsyncMysqlQueryErrorResult extends \AsyncMysqlQueryErrorResult {
 

--- a/src/AsyncMysql/AsyncMysqlQueryErrorResult.hack
+++ b/src/AsyncMysql/AsyncMysqlQueryErrorResult.hack
@@ -3,9 +3,8 @@ namespace Slack\SQLFake;
 <<__MockClass>>
 final class AsyncMysqlQueryErrorResult extends \AsyncMysqlQueryErrorResult {
 
-	public function __construct(private int $mysql_errno = 1105, private string $mysql_error = 'ERUnknownError') {
-		parent::__construct();
-	}
+	/* HH_IGNORE_ERROR[3012] I don't want to call parent::construct */
+	public function __construct(private int $mysql_errno = 1105, private string $mysql_error = 'ERUnknownError') {}
 
 	<<__Override>>
 	// HHAST_IGNORE_ERROR[CamelCasedMethodsUnderscoredFunctions]

--- a/src/AsyncMysql/AsyncMysqlQueryErrorResult.hack
+++ b/src/AsyncMysql/AsyncMysqlQueryErrorResult.hack
@@ -1,0 +1,20 @@
+namespace Slack\SQLFake;
+
+use namespace HH\Lib\C;
+
+<<__MockClass>>
+final class AsyncMysqlQueryErrorResult extends \AsyncMysqlQueryErrorResult {
+
+	/* HH_IGNORE_ERROR[3012] I don't want to call parent::construct */
+	public function __construct(private int $mysql_errno = 1105, private string $mysql_error = 'ERUnknownError') {}
+
+	<<__Override>>
+	public function mysql_errno(): int {
+		return $this->mysql_errno;
+	}
+
+	<<__Override>>
+	public function mysql_error(): string {
+		return $this->mysql_error;
+	}
+}

--- a/src/AsyncMysql/AsyncMysqlQueryErrorResult.php
+++ b/src/AsyncMysql/AsyncMysqlQueryErrorResult.php
@@ -1,3 +1,5 @@
+<?hh // strict
+
 namespace Slack\SQLFake;
 
 use namespace HH\Lib\C;

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -8,3 +8,11 @@ final class SQLFakeParseException extends SQLFakeException {}
 final class SQLFakeRuntimeException extends SQLFakeException {}
 final class SQLFakeUniqueKeyViolation extends SQLFakeException {}
 final class SQLFakeVitessQueryViolation extends SQLFakeException {}
+final class SQLFakeAsyncMysqlException extends SQLFakeException {
+	public function __construct(private \AsyncMysqlErrorResult $result) {
+		parent::__construct();
+	}
+	public function getResult(): \AsyncMysqlErrorResult {
+		return $this->result;
+	}
+}


### PR DESCRIPTION
Introduce `AsyncMysqlQueryErrorResult` and `SQLFakeAsyncMysqlException` to help verify mysql errors in tests.

Issue: https://github.com/slackhq/hack-sql-fake/issues/109